### PR TITLE
Index type hints

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -1,6 +1,7 @@
 from beanie.cursor import Cursor
 from beanie.documents import Document
 from beanie.general import init_beanie
+from beanie.collection import Indexed
 
 __version__ = "0.3.2"
-__all__ = ["Document", "Cursor", "init_beanie"]
+__all__ = ["Document", "Cursor", "init_beanie", "Indexed"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -311,7 +311,21 @@ class DocumentTestModelWithCustomCollectionName(Document):
 
 #### Indexes
 
-The indexes could be set up by the `indexes` field. It is a list where items could be:
+##### Simple indexes
+
+To setup an index over a single field the `Indexed` function can be used to wrap the type:
+
+```python
+from beanie import Indexed
+
+class DocumentTestModelWithIndex(Document):
+    test_int: Indexed(int)
+    test_list: List[SubDocument]
+    test_str: str
+```
+
+##### Complex indexes
+More complex indexes can be set up by the `indexes` field in a Collection class. It is a list where items could be:
 
 - single key. Name of the document's field
 - list of (key, direction) pairs. Key - string, name of the document's field. Direction - pymongo direction (
@@ -338,6 +352,8 @@ class DocumentTestModelWithIndex(Document):
             ),
         ]
 ```
+
+Complex and simple indices can be used in tandem.
 
 ### Use Motor Collection
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,7 +4,7 @@ import pymongo
 from pydantic import BaseModel
 from pymongo import IndexModel
 
-from beanie import Document
+from beanie import Document, Indexed
 
 
 class SubDocument(BaseModel):
@@ -28,6 +28,7 @@ class DocumentTestModelWithCustomCollectionName(Document):
 
 class DocumentTestModelWithIndex(Document):
     test_int: int
+    test_indexed_int: Indexed(int)
     test_list: List[SubDocument]
     test_str: str
 

--- a/tests/test_documents_init.py
+++ b/tests/test_documents_init.py
@@ -33,6 +33,7 @@ async def test_index_creation():
     assert index_info == {
         "_id_": {"key": [("_id", 1)], "v": 2},
         "test_int_1": {"key": [("test_int", 1)], "v": 2},
+        "test_indexed_int_1": {"key": [("test_indexed_int", 1)], "v": 2},
         "test_int_1_test_str_-1": {
             "key": [("test_int", 1), ("test_str", -1)],
             "v": 2,


### PR DESCRIPTION
Adds an additional less verbose way of adding indices using type hints:
```python
from beanie import Indexed

class DocumentTestModelWithIndex(Document):
    test_int: Indexed(int)
    test_list: List[SubDocument]
    test_str: str
```

I'm not sure the current method of implementing Indexed is the best, but it works and seems like a starting point.