### PR TITLE
Adds unique flag to Indexed field

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -14,14 +14,19 @@ from beanie.odm.operators.find.comparsion import (
 )
 
 
-def Indexed(typ, index_type=ASCENDING):
+def Indexed(typ, index_type=ASCENDING, unique=False):
     """
-    Returns a subclass of `typ` with an extra attribute `_indexed` et to True.
+    Returns a subclass of `typ` with an extra attribute `_indexed` as a tuple:
+    - Index 0 index type set to `pymongo.ASCENDING` or `pymongo.DESCENDING`
+    - Index 1 index unique set to False or True
     When instantiated the type of the result will actually be `typ`.
     """
 
+    if index_type not in (1, -1):
+        raise ValueError(f"Index Type ({index_type}) does not resolve to 1 or -1")
+
     class NewType(typ):
-        _indexed = index_type
+        _indexed = (index_type, unique)
 
         def __new__(cls, *args, **kwargs):
             return typ.__new__(typ, *args, **kwargs)

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -14,19 +14,16 @@ from beanie.odm.operators.find.comparsion import (
 )
 
 
-def Indexed(typ, index_type=ASCENDING, unique=False):
+def Indexed(typ, index_type=ASCENDING, **kwargs):
     """
     Returns a subclass of `typ` with an extra attribute `_indexed` as a tuple:
-    - Index 0 index type set to `pymongo.ASCENDING` or `pymongo.DESCENDING`
-    - Index 1 index unique set to False or True
+    - Index 0: `index_type` such as `pymongo.ASCENDING`
+    - Index 1: `kwargs` passed to `IndexModel`
     When instantiated the type of the result will actually be `typ`.
     """
 
-    if index_type not in (1, -1):
-        raise ValueError(f"Index Type ({index_type}) does not resolve to 1 or -1")
-
     class NewType(typ):
-        _indexed = (index_type, unique)
+        _indexed = (index_type, kwargs)
 
         def __new__(cls, *args, **kwargs):
             return typ.__new__(typ, *args, **kwargs)

--- a/beanie/odm/utils/collection.py
+++ b/beanie/odm/utils/collection.py
@@ -64,7 +64,7 @@ async def collection_factory(
 
     # Indexed field wrapped with Indexed()
     found_indexes = [
-        IndexModel([(fname, fvalue.type_._indexed[0])], unique=fvalue.type_._indexed[1])
+        IndexModel([(fname, fvalue.type_._indexed[0])], **fvalue.type_._indexed[1])
         for fname, fvalue in document_model.__fields__.items()
         if hasattr(fvalue.type_, "_indexed") and fvalue.type_._indexed
     ]

--- a/beanie/odm/utils/collection.py
+++ b/beanie/odm/utils/collection.py
@@ -64,7 +64,7 @@ async def collection_factory(
 
     # Indexed field wrapped with Indexed()
     found_indexes = [
-        IndexModel([(fname, fvalue.type_._indexed)])
+        IndexModel([(fname, fvalue.type_._indexed[0])], unique=fvalue.type_._indexed[1])
         for fname, fvalue in document_model.__fields__.items()
         if hasattr(fvalue.type_, "_indexed") and fvalue.type_._indexed
     ]

--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -10,6 +10,7 @@ from tests.odm.models import (
     SubDocument,
     DocumentTestModelWithCustomCollectionName,
     DocumentTestModelWithSimpleIndex,
+    DocumentTestModelWithIndexFlags,
     DocumentTestModelWithComplexIndex,
     DocumentTestModelFailInspection,
 )
@@ -87,6 +88,7 @@ async def init(loop, db):
         DocumentTestModel,
         DocumentTestModelWithCustomCollectionName,
         DocumentTestModelWithSimpleIndex,
+        DocumentTestModelWithIndexFlags,
         DocumentTestModelWithComplexIndex,
         DocumentTestModelFailInspection,
         Sample,

--- a/tests/odm/documents/test_init.py
+++ b/tests/odm/documents/test_init.py
@@ -8,6 +8,7 @@ from tests.odm.models import (
     DocumentTestModel,
     DocumentTestModelWithCustomCollectionName,
     DocumentTestModelWithSimpleIndex,
+    DocumentTestModelWithIndexFlags,
     DocumentTestModelWithComplexIndex,
     DocumentTestModelStringImport,
     DocumentTestModelWithDroppedIndex,
@@ -39,6 +40,15 @@ async def test_simple_index_creation():
         ("_fts", "text"),
         ("_ftsx", 1),
     ]
+
+
+async def test_flagged_index_creation():
+    collection: AsyncIOMotorCollection = (
+        DocumentTestModelWithIndexFlags.get_motor_collection()
+    )
+    index_info = await collection.index_information()
+    assert index_info["test_int_1"] == {"key": [("test_int", 1)], "sparse": True, "v": 2}
+    assert index_info["test_str_-1"] == {"key": [("test_str", -1)], "unique": True, "v": 2}
 
 
 async def test_complex_index_creation():

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -67,6 +67,11 @@ class DocumentTestModelWithSimpleIndex(Document):
     test_str: Indexed(str, index_type=pymongo.TEXT)
 
 
+class DocumentTestModelWithIndexFlags(Document):
+    test_int: Indexed(int, sparse=True)
+    test_str: Indexed(str, index_type=pymongo.DESCENDING, unique=True)
+
+
 class DocumentTestModelWithComplexIndex(Document):
     test_int: int
     test_list: List[SubDocument]


### PR DESCRIPTION
Adds the ability to create or integrate existing unique indexes using the `Indexed` field.

```python
class Plan(Document):
    key: Indexed(str, unique=True)
    name: str
    type: str
```

This is accomplished by turning `_indexed` into a tuple and passing the extra value(s) to `pymongo.IndexModel` as keyword parameters. This can be further extended to add other index attributes to the `Indexed` field init.

This functionality was already available in the code by using a list of `IndexModel` in a model's `Collection` definition, but adding this init kwarg is much more readable and concise. For clarification, it does not affect the index list method demoed in the [index demo](https://github.com/roman-right/beanie-index-demo/blob/28e4db0c1da76abf078cdd9efad9e4a936506205/beanie_index_demo/models/data_models.py#L25).