### PR TITLE
Added 'save' method and documented save/replace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,27 @@ the [documentation](https://roman-right.github.io/beanie/find/)
 
 ### Update
 
+#### Saving changes to existing documents
+
+The easiest way to change a document in the database is using either the `replace` or `save` methods on a altered document. These methods both write the document to the database, but `replace` will raise an exception when the document does not exist yet, while `save` will insert the document. 
+
+Using save:
+```python
+bar = await Product.find_one(Product.name == "Milka")
+bar.price = 10
+await bar.save()
+```
+Or similairly using replace, which trows a `ValueError` if the document does not have an `id` yet, or a `beanie.exceptions.DocumentNotFound` if it does but the id is not present in the collection:
+```python
+bar.price = 10
+try:
+    await bar.update()
+except (ValueError, beanie.exceptions.DocumentNotFound):
+    print("Can't replace a non existing document")
+```
+
+Note however that these methods requires multiple queries to the database and replace the entire document with the new version. A more tailered solution can often be created by applying update queries directly on the database level, see the explination below.
+
 #### Update Methods
 
 `Document`, `FindMany` and `FindOne`

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -24,6 +24,7 @@ from pymongo.results import (
 from beanie.exceptions import (
     CollectionWasNotInitialized,
     ReplaceError,
+    DocumentNotFound,
 )
 from beanie.odm.enums import SortDirection
 from beanie.odm.fields import PydanticObjectId, ExpressionField
@@ -298,6 +299,19 @@ class Document(BaseModel, UpdateMethods):
             self, session=session
         )
         return self
+
+    async def save(self, session: Optional[ClientSession] = None) -> DocType:
+        """
+        Update an existing model in the database or insert it if it does not yet exist.
+
+        :param session: Optional[ClientSession] - pymongo session.
+        :return: None
+        """
+
+        try:
+            return await self.replace(session=session)
+        except (ValueError, DocumentNotFound):
+            return await self.insert(session=session)
 
     @classmethod
     async def replace_many(

--- a/docs/index.md
+++ b/docs/index.md
@@ -242,6 +242,28 @@ the [documentation](https://roman-right.github.io/beanie/find/)
 
 ### Update
 
+#### Saving changes to existing documents
+
+The easiest way to change a document in the database is using either the `replace` or `save` methods on a altered document. These methods both write the document to the database, but `replace` will raise an exception when the document does not exist yet, while `save` will insert the document. 
+
+Using save:
+```python
+bar = await Product.find_one(Product.name == "Milka")
+bar.price = 10
+await bar.save()
+```
+Or similairly using replace, which trows a `ValueError` if the document does not have an `id` yet, or a `beanie.exceptions.DocumentNotFound` if it does but the id is not present in the collection:
+```python
+bar.price = 10
+try:
+    await bar.update()
+except (ValueError, beanie.exceptions.DocumentNotFound):
+    print("Can't replace a non existing document")
+```
+
+Note however that these methods requires multiple queries to the database and replace the entire document with the new version. A more tailered solution can often be created by applying update queries directly on the database level, see the explination below.
+
+
 #### Update Methods
 
 `Document`, `FindMany` and `FindOne`

--- a/tests/odm/documents/test_update.py
+++ b/tests/odm/documents/test_update.py
@@ -72,6 +72,37 @@ async def test_replace_not_found(document_not_inserted):
         await document_not_inserted.replace()
 
 
+# SAVE
+async def test_save(document):
+    update_data = {"test_str": "REPLACED_VALUE"}
+    new_doc = document.copy(update=update_data)
+    # document.test_str = "REPLACED_VALUE"
+    await new_doc.save()
+    new_document = await DocumentTestModel.get(document.id)
+    assert new_document.test_str == "REPLACED_VALUE"
+
+
+async def test_save_not_saved(document_not_inserted):
+    await document_not_inserted.save()
+    assert (
+        hasattr(document_not_inserted, "id")
+        and document_not_inserted.id is not None
+    )
+    from_db = await DocumentTestModel.get(document_not_inserted.id)
+    assert from_db == document_not_inserted
+
+
+async def test_save_not_found(document_not_inserted):
+    document_not_inserted.id = PydanticObjectId()
+    await document_not_inserted.save()
+    assert (
+        hasattr(document_not_inserted, "id")
+        and document_not_inserted.id is not None
+    )
+    from_db = await DocumentTestModel.get(document_not_inserted.id)
+    assert from_db == document_not_inserted
+
+
 # UPDATE
 
 


### PR DESCRIPTION
Although in many cases `update` is the more efficient option, i felt that the undocumented `replace` method might be more natural in many cases. I also added a `save` method which replaces an existing document or inserts a non-existing one and documented both at the top of the update section. 