### PR TITLE
Skip migration test when transactions not avalible

### DIFF
--- a/tests/migrations/test_free_fall.py
+++ b/tests/migrations/test_free_fall.py
@@ -1,6 +1,6 @@
 import pytest
 from pydantic.main import BaseModel
-
+from pymongo.errors import OperationFailure
 from beanie import init_beanie
 from beanie.executors.migrate import MigrationSettings, run_migrate
 from beanie.migrations.models import RunningDirections
@@ -41,8 +41,11 @@ async def notes(loop, db):
 
 
 async def test_migration_free_fall(settings, notes, db):
+    if not db.client.is_mongos and not len(db.client.nodes) > 1:
+        return pytest.skip(
+            "MongoDB server does not support transactions as it is neighter a mongos instance not a replica set."
+        )
 
-    # assert False
     migration_settings = MigrationSettings(
         connection_uri=settings.mongodb_dsn,
         database_name=settings.mongodb_db_name,


### PR DESCRIPTION
Addresses #43 

Not every developer will have mongodb setup using mongos or as a replica set. This skips the failing test when the functionality is not available. I could not test whether it does run the test when it is available as I had to go of documentation, so please check this.