### PR TITLE
Update annotations for update and delete

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -4,7 +4,7 @@ from beanie.odm.fields import PydanticObjectId, Indexed
 from beanie.odm.utils.general import init_beanie
 from beanie.odm.documents import Document
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"
 __all__ = [
     # ODM
     "Document",

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -192,7 +192,7 @@ class Document(BaseModel, UpdateMethods):
         *args: Union[Mapping[str, Any], bool],
         projection_model: Optional[Type[DocumentProjectionType]] = None,
         session: Optional[ClientSession] = None,
-    ):
+    ) -> Union[FindOne[DocType], FindOne[DocumentProjectionType]]:
         """
         Find one document by criteria.
         Returns [FindOne](https://roman-right.github.io/beanie/api/queries/#findone) query object.

--- a/beanie/odm/queries/delete.py
+++ b/beanie/odm/queries/delete.py
@@ -1,4 +1,4 @@
-from typing import Type, TYPE_CHECKING, Any, Mapping
+from typing import Generator, Type, TYPE_CHECKING, Any, Mapping
 
 from pymongo.results import DeleteResult
 
@@ -24,7 +24,7 @@ class DeleteQuery(SessionMethods):
 
 
 class DeleteMany(DeleteQuery):
-    def __await__(self) -> DeleteResult:
+    def __await__(self) -> Generator[DeleteResult, None, None]:
         """
         Run the query
         :return:
@@ -35,7 +35,7 @@ class DeleteMany(DeleteQuery):
 
 
 class DeleteOne(DeleteQuery):
-    def __await__(self) -> DeleteResult:
+    def __await__(self) -> Generator[DeleteResult, None, None]:
         """
         Run the query
         :return:

--- a/beanie/odm/queries/update.py
+++ b/beanie/odm/queries/update.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     Dict,
     Union,
+    Generator
 )
 
 from pymongo.client_session import ClientSession
@@ -91,10 +92,10 @@ class UpdateQuery(UpdateMethods, SessionMethods):
         return self
 
     @abstractmethod
-    async def _update(self):
+    async def _update(self) -> UpdateResult:
         ...
 
-    def __await__(self) -> Union[UpdateResult, InsertOneResult]:
+    def __await__(self) -> Generator[Any, None, Union[UpdateResult, InsertOneResult]]:
         """
         Run the query
         :return:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,18 @@
 
 Beanie project changes
 
-## [1.2.6] - 2021-07-21
+## [1.2.7] - 2021-09-01
+
+### Update
+
+- Annotations for update and delete
+
+### Implementation
+
+- Author - [Anthony Shaw](https://github.com/tonybaloney)
+- Issue - <https://github.com/roman-right/beanie/pull/106>
+
+## [1.2.6] - 2021-08-25
 
 ### Fixed
 
@@ -403,3 +414,5 @@ Beanie project changes
 [1.2.5]: https://pypi.org/project/beanie/1.2.5
 
 [1.2.6]: https://pypi.org/project/beanie/1.2.6
+
+[1.2.7]: https://pypi.org/project/beanie/1.2.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beanie"
-version = "1.2.6"
+version = "1.2.7"
 description = "Asynchronous Python ODM for MongoDB"
 authors = ["Roman <roman-right@protonmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.2.6"
+    assert __version__ == "1.2.7"


### PR DESCRIPTION
This solves 3 issues:

1. `await self.find_one({"_id": self.id}).delete(session=session)` would be marked as "delete()" is not awaitable, because the `DeleteOne.__await__()` wasn't annotated as a generator with the correct return type
1. `Documents.find_one()` wasn't annotated causing warnings in other places
1.  Same as 1 but with `update()`.

There is still an issue with the `delete()` methods:

```python
    async def delete(
        self, session: Optional[ClientSession] = None
    ) -> DeleteResult:
        """
        Delete the document

        :param session: Optional[ClientSession] - pymongo session.
        :return: DeleteResult - pymongo DeleteResult instance.
        """
        return await self.find_one({"_id": self.id}).delete(session=session)

    @classmethod
    async def delete_all(
        cls, session: Optional[ClientSession] = None
    ) -> DeleteResult:
        """
        Delete all the documents

        :param session: Optional[ClientSession] - pymongo session.
        :return: DeleteResult - pymongo DeleteResult instance.
        """
        return await cls.find_all().delete(session=session)
```

Technically, `find_all().delete().__await__()` could return `None` since it is a generator. So the return type of `DeleteResult` is not entirely accurate?