### PR TITLE
[WIP] Simplify indexed fields

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -1,7 +1,10 @@
+from typing import Generic, TypeVar
+
 from bson import ObjectId
 from bson.errors import InvalidId
 from pydantic.json import ENCODERS_BY_TYPE
-from pymongo import ASCENDING
+from pydantic.generics import GenericModel
+import pymongo
 
 from beanie.odm.enums import SortDirection
 from beanie.odm.operators.find.comparison import (
@@ -13,8 +16,26 @@ from beanie.odm.operators.find.comparison import (
     NE,
 )
 
+_IndexedType = TypeVar("_IndexedType")
 
-def Indexed(typ, index_type=ASCENDING, **kwargs):
+
+class AscendingIndex(GenericModel, Generic[_IndexedType]):
+    _indexed = (pymongo.ASCENDING, {})
+
+
+class DescendingIndex(GenericModel, Generic[_IndexedType]):
+    _indexed = (pymongo.DESCENDING, {})
+
+
+class HashedIndex(GenericModel, Generic[_IndexedType]):
+    _indexed = (pymongo.HASHED, {})
+
+
+class TextIndex(GenericModel):
+    _indexed = (pymongo.TEXT, {})
+
+
+def Indexed(typ, index_type=pymongo.ASCENDING, **kwargs):
     """
     Returns a subclass of `typ` with an extra attribute `_indexed` as a tuple:
     - Index 0: `index_type` such as `pymongo.ASCENDING`

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -1,3 +1,4 @@
+import beanie.odm.fields as fields
 import datetime
 from typing import List
 from typing import Union, Optional, Tuple
@@ -131,3 +132,16 @@ class DocumentWithCustomIdUUID(Document):
 class DocumentWithCustomIdInt(Document):
     id: int
     name: str
+
+
+class DocumentTestModelWithTypedIndexFields(Document):
+    test_int: fields.AscendingIndex[int] = Field(alias="testInt")
+    test_str: fields.DescendingIndex[str] = Field(alias="testStr")
+
+
+class DocumentTestModelWithHashedIndexes(Document):
+    test_str: fields.HashedIndex[str] = Field(alias="testStr")
+
+
+class DocumentTestModelWithTextIndexes(Document):
+    test_str: fields.TextIndex = Field(alias="testStr")


### PR DESCRIPTION
Adds types for indexed fields

```python
class DocumentExample(Document):
   example1 : Indexed(str, pymongo.ASCENDING)
```

would become

```python
class DocumentExample(Document):
   example1 : Indexed(str, pymongo.HASHED)
```

would become

```python
class DocumentExample(Document):
   example1 : HashedIndex[str]
```

* The names of the types are a bit confusing, as they're indexed fields, suggestions?
* Do you like this API?
* This solves #105 
* This could be extended for GeoJSON GeoSphere and Geo2D indexes, but that example is a bit more complicated