### PR TITLE
Bulk write operation

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -8,6 +8,7 @@ from beanie.odm.actions import (
     SaveChanges,
     ValidateOnSave,
 )
+from beanie.odm.bulk import BulkWriter
 from beanie.odm.fields import PydanticObjectId, Indexed
 from beanie.odm.utils.general import init_beanie
 from beanie.odm.documents import Document
@@ -26,6 +27,8 @@ __all__ = [
     "Replace",
     "SaveChanges",
     "ValidateOnSave",
+    # Bulk Write
+    "BulkWriter",
     # Migrations
     "iterative_migration",
     "free_fall_migration",

--- a/beanie/odm/bulk.py
+++ b/beanie/odm/bulk.py
@@ -1,0 +1,62 @@
+from typing import Dict, Any, List, Optional, Union, Type
+
+from pydantic import BaseModel
+from pymongo import (
+    InsertOne,
+    DeleteOne,
+    DeleteMany,
+    ReplaceOne,
+    UpdateOne,
+    UpdateMany,
+)
+
+
+class Operation(BaseModel):
+    operation: Union[
+        Type[InsertOne],
+        Type[DeleteOne],
+        Type[DeleteMany],
+        Type[ReplaceOne],
+        Type[UpdateOne],
+        Type[UpdateMany],
+    ]
+    first_query: Dict[str, Any]
+    second_query: Optional[Dict[str, Any]] = None
+    object_class: Type
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class BulkWriter:
+    def __init__(self):
+        self.operations: List[Operation] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.commit()
+
+    async def commit(self):
+        obj_class = None
+        requests = []
+        if self.operations:
+            for op in self.operations:
+                if obj_class is None:
+                    obj_class = op.object_class
+
+                if obj_class != op.object_class:
+                    raise ValueError(
+                        "All the operations should be for a single document model"
+                    )
+                if op.operation in [InsertOne, DeleteOne]:
+                    query = op.operation(op.first_query)
+                else:
+                    query = op.operation(op.first_query, op.second_query)
+                requests.append(query)
+
+            await obj_class.get_motor_collection().bulk_write(requests)
+
+    def add_operation(self, operation: Operation):
+        self.operations.append(operation)

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -21,6 +21,7 @@ from pydantic import (
     validator,
 )
 from pydantic.main import BaseModel
+from pymongo import InsertOne
 from pymongo.client_session import ClientSession
 from pymongo.results import (
     DeleteResult,
@@ -35,6 +36,7 @@ from beanie.exceptions import (
     RevisionIdWasChanged,
 )
 from beanie.odm.actions import EventTypes, wrap_with_actions
+from beanie.odm.bulk import BulkWriter, Operation
 from beanie.odm.enums import SortDirection
 from beanie.odm.fields import PydanticObjectId, ExpressionField
 from beanie.odm.interfaces.update import (
@@ -114,7 +116,8 @@ class Document(BaseModel, UpdateMethods):
     @save_state_after
     @validate_self_before
     async def insert(
-        self: DocType, session: Optional[ClientSession] = None
+        self: DocType,
+        session: Optional[ClientSession] = None,
     ) -> DocType:
         """
         Insert the document (self) to the collection
@@ -130,7 +133,8 @@ class Document(BaseModel, UpdateMethods):
         return self
 
     async def create(
-        self: DocType, session: Optional[ClientSession] = None
+        self: DocType,
+        session: Optional[ClientSession] = None,
     ) -> DocType:
         """
         The same as self.insert()
@@ -143,20 +147,31 @@ class Document(BaseModel, UpdateMethods):
         cls: Type[DocType],
         document: DocType,
         session: Optional[ClientSession] = None,
+        bulk_writer: "BulkWriter" = None,
     ) -> InsertOneResult:
         """
         Insert one document to the collection
         :param document: Document - document to insert
         :param session: ClientSession - pymongo session
+        :param bulk_writer: "BulkWriter" - Beanie bulk writer
         :return: InsertOneResult
         """
         if not isinstance(document, cls):
             raise TypeError(
                 "Inserting document must be of the original document class"
             )
-        return await cls.get_motor_collection().insert_one(
-            get_dict(document), session=session
-        )
+        if bulk_writer is None:
+            return await cls.get_motor_collection().insert_one(
+                get_dict(document), session=session
+            )
+        else:
+            bulk_writer.add_operation(
+                Operation(
+                    operation=InsertOne,
+                    first_query=get_dict(document),
+                    object_class=type(document),
+                )
+            )
 
     @classmethod
     async def insert_many(
@@ -448,8 +463,9 @@ class Document(BaseModel, UpdateMethods):
     @validate_self_before
     async def replace(
         self: DocType,
-        session: Optional[ClientSession] = None,
         force: bool = False,
+        session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
     ) -> DocType:
         """
         Fully update the document in the database
@@ -457,6 +473,7 @@ class Document(BaseModel, UpdateMethods):
         :param session: Optional[ClientSession] - pymongo session.
         :param force: bool - do force replace.
             Used when revision based protection is turned on.
+        :param bulk_writer: "BulkWriter" - Beanie bulk writer
         :return: self
         """
         if self.id is None:
@@ -468,9 +485,10 @@ class Document(BaseModel, UpdateMethods):
 
         if use_revision_id and not force:
             find_query["revision_id"] = self._previous_revision_id
-
         try:
-            await self.find_one(find_query).replace_one(self, session=session)
+            await self.find_one(find_query).replace_one(
+                self, session=session, bulk_writer=bulk_writer
+            )
         except DocumentNotFound:
             if use_revision_id and not force:
                 raise RevisionIdWasChanged
@@ -496,18 +514,26 @@ class Document(BaseModel, UpdateMethods):
     @saved_state_needed
     @wrap_with_actions(EventTypes.SAVE_CHANGES)
     @validate_self_before
-    async def save_changes(self, force: bool = False) -> None:
+    async def save_changes(
+        self,
+        force: bool = False,
+        session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
+    ) -> None:
         """
         Save changes.
         State management usage must be turned on
 
         :param force: bool - ignore revision id, if revision is turned on
+        :param bulk_writer: "BulkWriter" - Beanie bulk writer
         :return: None
         """
         if not self.is_changed:
             return None
         changes = self.get_changes()
-        await self.set(changes, force=force)  # type: ignore #TODO fix typing
+        await self.set(
+            changes, force=force, session=session, bulk_writer=bulk_writer
+        )  # type: ignore #TODO fix typing
 
     @classmethod
     async def replace_many(
@@ -534,8 +560,9 @@ class Document(BaseModel, UpdateMethods):
     async def update(
         self,
         *args,
-        session: Optional[ClientSession] = None,
         force: bool = False,
+        session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
     ) -> None:
         """
         Partially update the document in the database
@@ -544,6 +571,7 @@ class Document(BaseModel, UpdateMethods):
         :param session: ClientSession - pymongo session.
         :param force: bool - force update. Will update even if revision id
         is not the same, as stored
+        :param bulk_writer: "BulkWriter" - Beanie bulk writer
         :return: None
         """
         use_revision_id = self.get_settings().model_settings.use_revision
@@ -553,7 +581,9 @@ class Document(BaseModel, UpdateMethods):
         if use_revision_id and not force:
             find_query["revision_id"] = self._previous_revision_id
 
-        result = await self.find_one(find_query).update(*args, session=session)
+        result = await self.find_one(find_query).update(
+            *args, session=session, bulk_writer=bulk_writer
+        )
 
         if use_revision_id and not force and result.modified_count == 0:
             raise RevisionIdWasChanged
@@ -564,38 +594,52 @@ class Document(BaseModel, UpdateMethods):
         cls,
         *args: Union[dict, Mapping],
         session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
     ) -> UpdateMany:
         """
         Partially update all the documents
 
         :param args: *Union[dict, Mapping] - the modifications to apply.
         :param session: ClientSession - pymongo session.
+        :param bulk_writer: "BulkWriter" - Beanie bulk writer
         :return: UpdateMany query
         """
-        return cls.find_all().update_many(*args, session=session)
+        return cls.find_all().update_many(
+            *args, session=session, bulk_writer=bulk_writer
+        )
 
     async def delete(
-        self, session: Optional[ClientSession] = None
+        self,
+        session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
     ) -> Optional[DeleteResult]:
         """
         Delete the document
 
         :param session: Optional[ClientSession] - pymongo session.
+        :param bulk_writer: "BulkWriter" - Beanie bulk writer
         :return: Optional[DeleteResult] - pymongo DeleteResult instance.
         """
-        return await self.find_one({"_id": self.id}).delete(session=session)
+        return await self.find_one({"_id": self.id}).delete(
+            session=session, bulk_writer=bulk_writer
+        )
 
     @classmethod
     async def delete_all(
-        cls, session: Optional[ClientSession] = None
+        cls,
+        session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
     ) -> Optional[DeleteResult]:
         """
         Delete all the documents
 
         :param session: Optional[ClientSession] - pymongo session.
+        :param bulk_writer: "BulkWriter" - Beanie bulk writer
         :return: Optional[DeleteResult] - pymongo DeleteResult instance.
         """
-        return await cls.find_all().delete(session=session)
+        return await cls.find_all().delete(
+            session=session, bulk_writer=bulk_writer
+        )
 
     @overload
     @classmethod

--- a/beanie/odm/interfaces/update.py
+++ b/beanie/odm/interfaces/update.py
@@ -3,6 +3,7 @@ from typing import Dict, Mapping, Union, Any, Optional
 
 from pymongo.client_session import ClientSession
 
+from beanie.odm.bulk import BulkWriter
 from beanie.odm.fields import ExpressionField
 from beanie.odm.operators.update.general import (
     Set,
@@ -21,6 +22,7 @@ class UpdateMethods:
         self,
         *args: Mapping[str, Any],
         session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
         **kwargs
     ):
         return self
@@ -29,6 +31,7 @@ class UpdateMethods:
         self,
         expression: Dict[Union[ExpressionField, str], Any],
         session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
         **kwargs
     ):
         """
@@ -50,14 +53,18 @@ class UpdateMethods:
         :param expression: Dict[Union[ExpressionField, str], Any] - keys and
         values to set
         :param session: Optional[ClientSession] - pymongo session
+        :param bulk_writer: Optional[BulkWriter] - bulk writer
         :return: self
         """
-        return self.update(Set(expression), session=session, **kwargs)
+        return self.update(
+            Set(expression), session=session, bulk_writer=bulk_writer, **kwargs
+        )
 
     def current_date(
         self,
         expression: Dict[Union[ExpressionField, str], Any],
         session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
         **kwargs
     ):
         """
@@ -67,14 +74,21 @@ class UpdateMethods:
 
         :param expression: Dict[Union[ExpressionField, str], Any]
         :param session: Optional[ClientSession] - pymongo session
+        :param bulk_writer: Optional[BulkWriter] - bulk writer
         :return: self
         """
-        return self.update(CurrentDate(expression), session=session, **kwargs)
+        return self.update(
+            CurrentDate(expression),
+            session=session,
+            bulk_writer=bulk_writer,
+            **kwargs
+        )
 
     def inc(
         self,
         expression: Dict[Union[ExpressionField, str], Any],
         session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
         **kwargs
     ):
         """
@@ -95,6 +109,9 @@ class UpdateMethods:
 
         :param expression: Dict[Union[ExpressionField, str], Any]
         :param session: Optional[ClientSession] - pymongo session
+        :param bulk_writer: Optional[BulkWriter] - bulk writer
         :return: self
         """
-        return self.update(Inc(expression), session=session, **kwargs)
+        return self.update(
+            Inc(expression), session=session, bulk_writer=bulk_writer, **kwargs
+        )

--- a/beanie/odm/queries/find.py
+++ b/beanie/odm/queries/find.py
@@ -17,7 +17,10 @@ from typing import (
     overload,
 )
 
+from pymongo import ReplaceOne
+
 from beanie.exceptions import DocumentNotFound
+from beanie.odm.bulk import BulkWriter, Operation
 from beanie.odm.enums import SortDirection
 from beanie.odm.interfaces.aggregate import AggregateMethods
 from beanie.odm.interfaces.session import SessionMethods
@@ -92,6 +95,7 @@ class FindQuery(Generic[FindQueryResultType], UpdateMethods, SessionMethods):
         self,
         *args: Mapping[str, Any],
         session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
         **kwargs,
     ):
         """
@@ -108,7 +112,7 @@ class FindQuery(Generic[FindQueryResultType], UpdateMethods, SessionMethods):
                 document_model=self.document_model,
                 find_query=self.get_filter_query(),
             )
-            .update(*args)
+            .update(*args, bulk_writer=bulk_writer)
             .set_session(session=self.session)
         )
 
@@ -139,7 +143,9 @@ class FindQuery(Generic[FindQueryResultType], UpdateMethods, SessionMethods):
         )
 
     def delete(
-        self, session: Optional[ClientSession] = None
+        self,
+        session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
     ) -> Union[DeleteOne, DeleteMany]:
         """
         Provide search criteria to the Delete query
@@ -151,6 +157,7 @@ class FindQuery(Generic[FindQueryResultType], UpdateMethods, SessionMethods):
         return self.DeleteQueryType(
             document_model=self.document_model,
             find_query=self.get_filter_query(),
+            bulk_writer=bulk_writer,
         ).set_session(session=session)
 
     def project(
@@ -391,7 +398,10 @@ class FindMany(
         return self
 
     def update_many(
-        self, *args: Mapping[str, Any], session: Optional[ClientSession] = None
+        self,
+        *args: Mapping[str, Any],
+        session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
     ) -> UpdateMany:
         """
         Provide search criteria to the
@@ -401,10 +411,15 @@ class FindMany(
         :param session: Optional[ClientSession]
         :return: [UpdateMany](https://roman-right.github.io/beanie/api/queries/#updatemany) query
         """
-        return cast(UpdateMany, self.update(*args, session=session))
+        return cast(
+            UpdateMany,
+            self.update(*args, session=session, bulk_writer=bulk_writer),
+        )
 
     def delete_many(
-        self, session: Optional[ClientSession] = None
+        self,
+        session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
     ) -> DeleteMany:
         """
         Provide search criteria to the [DeleteMany](https://roman-right.github.io/beanie/api/queries/#deletemany) query
@@ -415,7 +430,9 @@ class FindMany(
         # We need to cast here to tell mypy that we are sure about the type.
         # This is because delete may also return a DeleteOne type in general, and mypy can not be sure in this case
         # See https://mypy.readthedocs.io/en/stable/common_issues.html#narrowing-and-inner-functions
-        return cast(DeleteMany, self.delete(session=session))
+        return cast(
+            DeleteMany, self.delete(session=session, bulk_writer=bulk_writer)
+        )
 
     async def count(self) -> int:
         """
@@ -567,7 +584,10 @@ class FindOne(FindQuery[FindQueryResultType]):
         return self
 
     def update_one(
-        self, *args: Mapping[str, Any], session: Optional[ClientSession] = None
+        self,
+        *args: Mapping[str, Any],
+        session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
     ) -> UpdateOne:
         """
         Create [UpdateOne](https://roman-right.github.io/beanie/api/queries/#updateone) query using modifications and
@@ -576,9 +596,16 @@ class FindOne(FindQuery[FindQueryResultType]):
         :param session: Optional[ClientSession] - PyMongo sessions
         :return: [UpdateOne](https://roman-right.github.io/beanie/api/queries/#updateone) query
         """
-        return cast(UpdateOne, self.update(*args, session=session))
+        return cast(
+            UpdateOne,
+            self.update(*args, session=session, bulk_writer=bulk_writer),
+        )
 
-    def delete_one(self, session: Optional[ClientSession] = None) -> DeleteOne:
+    def delete_one(
+        self,
+        session: Optional[ClientSession] = None,
+        bulk_writer: Optional[BulkWriter] = None,
+    ) -> DeleteOne:
         """
         Provide search criteria to the [DeleteOne](https://roman-right.github.io/beanie/api/queries/#deleteone) query
         :param session: Optional[ClientSession] - PyMongo sessions
@@ -587,31 +614,50 @@ class FindOne(FindQuery[FindQueryResultType]):
         # We need to cast here to tell mypy that we are sure about the type.
         # This is because delete may also return a DeleteOne type in general, and mypy can not be sure in this case
         # See https://mypy.readthedocs.io/en/stable/common_issues.html#narrowing-and-inner-functions
-        return cast(DeleteOne, self.delete(session=session))
+        return cast(
+            DeleteOne, self.delete(session=session, bulk_writer=bulk_writer)
+        )
 
     async def replace_one(
         self,
         document: "DocType",
         session: Optional[ClientSession] = None,
-    ) -> UpdateResult:
+        bulk_writer: Optional[BulkWriter] = None,
+    ) -> Optional[UpdateResult]:
         """
         Replace found document by provided
         :param document: Document - document, which will replace the found one
         :param session: Optional[ClientSession] - PyMongo session
+        :param bulk_writer: Optional[BulkWriter] - Beanie bulk writer
         :return: UpdateResult
         """
         self.set_session(session=session)
-        result: UpdateResult = (
-            await self.document_model.get_motor_collection().replace_one(
-                self.get_filter_query(),
-                bson_encoder.encode(document, by_alias=True, exclude={"id"}),
-                session=self.session,
+        if bulk_writer is None:
+            result: UpdateResult = (
+                await self.document_model.get_motor_collection().replace_one(
+                    self.get_filter_query(),
+                    bson_encoder.encode(
+                        document, by_alias=True, exclude={"id"}
+                    ),
+                    session=self.session,
+                )
             )
-        )
 
-        if not result.raw_result["updatedExisting"]:
-            raise DocumentNotFound
-        return result
+            if not result.raw_result["updatedExisting"]:
+                raise DocumentNotFound
+            return result
+        else:
+            bulk_writer.add_operation(
+                Operation(
+                    operation=ReplaceOne,
+                    first_query=self.get_filter_query(),
+                    second_query=bson_encoder.encode(
+                        document, by_alias=True, exclude={"id"}
+                    ),
+                    object_class=self.document_model,
+                )
+            )
+            return None
 
     def __await__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ pydoc-markdown = "^3.13.0"
 flake8 = "^3.9.1"
 pyright = "^0.0.2"
 mkdocs = "1.1"
+icecream = "^2.1.1"
 
 
 [build-system]

--- a/tests/odm/documents/test_bulk_write.py
+++ b/tests/odm/documents/test_bulk_write.py
@@ -1,0 +1,109 @@
+import pytest
+from pymongo.errors import BulkWriteError
+
+from beanie.odm.bulk import BulkWriter
+from beanie.odm.operators.update.general import Set
+from tests.odm.models import DocumentTestModel
+
+
+async def test_insert(documents_not_inserted):
+    documents = documents_not_inserted(2)
+    async with BulkWriter() as bulk_writer:
+        await DocumentTestModel.insert_one(
+            documents[0], bulk_writer=bulk_writer
+        )
+        await DocumentTestModel.insert_one(
+            documents[1], bulk_writer=bulk_writer
+        )
+
+    new_documents = await DocumentTestModel.find_all().to_list()
+    assert len(new_documents) == 2
+
+
+async def test_update(documents, document_not_inserted):
+    await documents(5)
+    doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 0)
+    doc.test_int = 100
+    async with BulkWriter() as bulk_writer:
+        await doc.save_changes(bulk_writer=bulk_writer)
+        await DocumentTestModel.find_one(
+            DocumentTestModel.test_int == 1
+        ).update(
+            Set({DocumentTestModel.test_int: 1000}), bulk_writer=bulk_writer
+        )
+        await DocumentTestModel.find(DocumentTestModel.test_int < 100).update(
+            Set({DocumentTestModel.test_int: 2000}), bulk_writer=bulk_writer
+        )
+
+    assert len(await DocumentTestModel.find_all().to_list()) == 5
+    assert (
+        len(
+            await DocumentTestModel.find(
+                DocumentTestModel.test_int == 100
+            ).to_list()
+        )
+        == 1
+    )
+    assert (
+        len(
+            await DocumentTestModel.find(
+                DocumentTestModel.test_int == 1000
+            ).to_list()
+        )
+        == 1
+    )
+    assert (
+        len(
+            await DocumentTestModel.find(
+                DocumentTestModel.test_int == 2000
+            ).to_list()
+        )
+        == 3
+    )
+
+
+async def test_delete(documents, document_not_inserted):
+    await documents(5)
+    doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 0)
+    async with BulkWriter() as bulk_writer:
+        await doc.delete(bulk_writer=bulk_writer)
+        await DocumentTestModel.find_one(
+            DocumentTestModel.test_int == 1
+        ).delete(bulk_writer=bulk_writer)
+        await DocumentTestModel.find(DocumentTestModel.test_int < 4).delete(
+            bulk_writer=bulk_writer
+        )
+
+    assert len(await DocumentTestModel.find_all().to_list()) == 1
+
+
+async def test_replace(documents, document_not_inserted):
+    await documents(5)
+    doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 0)
+    doc.test_int = 100
+    async with BulkWriter() as bulk_writer:
+        await doc.replace(bulk_writer=bulk_writer)
+
+        document_not_inserted.test_int = 100
+
+        await DocumentTestModel.find_one(
+            DocumentTestModel.test_int == 1
+        ).replace_one(document_not_inserted, bulk_writer=bulk_writer)
+
+    assert len(await DocumentTestModel.find_all().to_list()) == 5
+    assert (
+        len(
+            await DocumentTestModel.find(
+                DocumentTestModel.test_int == 100
+            ).to_list()
+        )
+        == 2
+    )
+
+
+async def test_internal_error(document):
+    with pytest.raises(BulkWriteError):
+        async with BulkWriter() as bulk_writer:
+            await DocumentTestModel.insert_one(
+                document, bulk_writer=bulk_writer
+            )

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -63,6 +63,9 @@ class DocumentTestModel(Document):
     test_list: List[SubDocument]
     test_str: str
 
+    class Settings:
+        use_state_management = True
+
 
 class DocumentTestModelWithCustomCollectionName(Document):
     test_int: int


### PR DESCRIPTION
It allows sending Inserts, updates, replaces and deletions as a single query to MongoDB

Implemented:
- BulkWriter - async context manager
- Added support to the respective operations