### PR TITLE
Add auto_index option

### DIFF
--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -843,13 +843,17 @@ class Document(BaseModel, UpdateMethods):
 
     @classmethod
     async def init_settings(
-        cls, database: AsyncIOMotorDatabase, allow_index_dropping: bool
+        cls,
+        database: AsyncIOMotorDatabase,
+        allow_index_dropping: bool,
+        auto_index: bool,
     ) -> None:
         """
         Init document settings (collection and models)
 
         :param database: AsyncIOMotorDatabase - motor database
         :param allow_index_dropping: bool
+        :param auto_index: bool
         :return: None
         """
         # TODO looks ugly a little. Too many parameters transfers.
@@ -857,20 +861,27 @@ class Document(BaseModel, UpdateMethods):
             database=database,
             document_model=cls,
             allow_index_dropping=allow_index_dropping,
+            auto_index=auto_index,
         )
 
     @classmethod
     async def init_model(
-        cls, database: AsyncIOMotorDatabase, allow_index_dropping: bool
+        cls,
+        database: AsyncIOMotorDatabase,
+        allow_index_dropping: bool,
+        auto_index: bool,
     ) -> None:
         """
         Init wrapper
         :param database: AsyncIOMotorDatabase
         :param allow_index_dropping: bool
+        :param auto_index: bool
         :return: None
         """
         await cls.init_settings(
-            database=database, allow_index_dropping=allow_index_dropping
+            database=database,
+            allow_index_dropping=allow_index_dropping,
+            auto_index=auto_index,
         )
         cls.init_fields()
         cls.init_cache()

--- a/beanie/odm/settings/general.py
+++ b/beanie/odm/settings/general.py
@@ -10,12 +10,15 @@ class DocumentSettings:
     collection_settings: CollectionSettings
 
     @classmethod
-    async def init(cls, database, document_model, allow_index_dropping):
+    async def init(
+        cls, database, document_model, allow_index_dropping, auto_index
+    ):
         # Init collection settings
         collection_settings = await CollectionSettings.init(
             database=database,
             document_model=document_model,
             allow_index_dropping=allow_index_dropping,
+            auto_index=auto_index,
         )
 
         # Init model settings

--- a/beanie/odm/utils/general.py
+++ b/beanie/odm/utils/general.py
@@ -37,7 +37,7 @@ async def init_beanie(
     connection_string: str = None,
     document_models: List[Union[Type["DocType"], str]] = None,
     allow_index_dropping: bool = True,
-    auto_index: bool =True,
+    auto_index: bool = True,
 ):
     """
     Beanie initialization

--- a/beanie/odm/utils/general.py
+++ b/beanie/odm/utils/general.py
@@ -37,6 +37,7 @@ async def init_beanie(
     connection_string: str = None,
     document_models: List[Union[Type["DocType"], str]] = None,
     allow_index_dropping: bool = True,
+    auto_index: bool =True,
 ):
     """
     Beanie initialization
@@ -46,6 +47,8 @@ async def init_beanie(
     :param document_models: List[Union[Type[DocType], str]] - model classes
     or strings with dot separated paths
     :param allow_index_dropping: bool - if index dropping is allowed.
+    Default True
+    :param auto_index: bool - if auto_index is enabled.
     Default True
     :return: None
     """
@@ -69,7 +72,9 @@ async def init_beanie(
             model = get_model(model)
         collection_inits.append(
             model.init_model(
-                database, allow_index_dropping=allow_index_dropping
+                database,
+                allow_index_dropping=allow_index_dropping,
+                auto_index=auto_index,
             )
         )
 

--- a/tests/odm/documents/test_init.py
+++ b/tests/odm/documents/test_init.py
@@ -168,6 +168,7 @@ async def test_index_dropping_is_not_allowed(db):
         "test_string_index_DESCENDING": {"key": [("test_str", -1)], "v": 2},
     }
 
+
 async def auto_index_is_disabled(db):
     await init_beanie(
         database=db, document_models=[DocumentTestModelWithComplexIndex]
@@ -190,7 +191,7 @@ async def auto_index_is_disabled(db):
             "v": 2,
         },
         "test_string_index_DESCENDING": {"key": [("test_str", -1)], "v": 2},
-    }    
+    }
 
 
 async def test_document_string_import(db):

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -141,6 +141,7 @@ class DocumentTestModelWithModifiedIndexs(Document):
             "test_list.test_str",
         ]
 
+
 class DocumentTestModelStringImport(Document):
     test_int: int
 

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -129,6 +129,18 @@ class DocumentTestModelWithDroppedIndex(Document):
         ]
 
 
+class DocumentTestModelWithModifiedIndexs(Document):
+    test_int: int
+    test_list: List[SubDocument]
+    test_str: str
+
+    class Collection:
+        name = "docs_with_index"
+        indexes = [
+            "test_int",
+            "test_list.test_str",
+        ]
+
 class DocumentTestModelStringImport(Document):
     test_int: int
 


### PR DESCRIPTION
Actually, this PR is to solve one issue that using multiple beanie clients in "forked" multi-process often hang on `init_beanie`. That deeper part is it would hang on `old_indexes = (await collection.index_information()).keys()`. I think it is an issue on `pymongo` side and https://pymongo.readthedocs.io/en/stable/faq.html#is-pymongo-fork-safe indicates it will be safe if instantiating a new `pymongo` client but I guess it still may have some potential issues, even doing so, just like this issue I met. If I have time, I may open a issue on pymongo repo.

So this is to skip the auto index part code. It may be still valuable that sometimes you can turn off this auto_index, like in production, or anytime. [mongoengine](https://github.com/MongoEngine/mongoengine/blob/5fe9436ea7bd2f47812b017104285210848a1276/mongoengine/document.py#L873) mentioned by @snjypl in discord, and JavaScript famous [mongoose](https://mongoosejs.com/docs/guide.html#indexes) both have this option.