### PR TITLE
style: import motor.motor_asyncio to eliminate Pylance error

### DIFF
--- a/beanie/migrations/database.py
+++ b/beanie/migrations/database.py
@@ -1,4 +1,4 @@
-import motor
+import motor.motor_asyncio
 
 
 class DBHandler:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ Getting Beanie setup in your code is really easy:
 from typing import Optional
 from pydantic import BaseModel
 from beanie import Document, Indexed, init_beanie
-import motor
+import motor.motor_asyncio
 
 class Category(BaseModel):
     name: str

--- a/docs/tutorial/init.md
+++ b/docs/tutorial/init.md
@@ -1,7 +1,7 @@
 Beanie uses Motor as an async database engine. To init previously created documents, you should provide a Motor database instance and list of your document models to the `init_beanie(...)` function, as it is shown in the example:
 ```python
 from beanie import init_beanie, Document
-import motor
+import motor.motor_asyncio
 
 class Sample(Document):
     name: str


### PR DESCRIPTION
To solve one of the Pylance errors in ref: #142. 

This usage is referred from motor doc site: https://motor.readthedocs.io/en/stable/tutorial-asyncio.html  