### PR TITLE
Fix typo from docs/tutorial/aggregates.md

### DIFF
--- a/docs/tutorial/aggregate.md
+++ b/docs/tutorial/aggregate.md
@@ -9,7 +9,6 @@ avg_price = await Product.find(
 ).avg(Product.price)
 
 # Over the whole collection:
-```python
 avg_price = await Product.avg(Product.price)
 ```
 


### PR DESCRIPTION
**AS-IS**
There was a markdown code block text in docs/tutorial/aggregates.md
```
...
```python
...
```

**TO-BE**
Deleted the text.