### PR TITLE
Add exclude_hidden to dict()

### DIFF
--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -9,7 +9,7 @@ jobs:
         python-version: [ 3.7, 3.8, 3.9 ]
         poetry-version: [ 1.1.4 ]
         mongodb-version: [ 4.4, 5.0 ]
-        pydantic-version: [1.7.4, 1.9.0]
+        pydantic-version: [1.9.0]
         os: [ ubuntu-18.04 ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -9,7 +9,7 @@ jobs:
         python-version: [ 3.7, 3.8, 3.9 ]
         poetry-version: [ 1.1.4 ]
         mongodb-version: [ 4.4, 5.0 ]
-        pydantic-version: [1.7.4, 1.8.2]
+        pydantic-version: [1.7.4, 1.9.0]
         os: [ ubuntu-18.04 ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ tests/assets/tmp
 src/api_files/storage_dir
 docker-compose-aws.yml
 tilt_modules
+
+# Poetry stuff
+poetry.lock

--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -19,7 +19,7 @@ from beanie.odm.fields import (
 from beanie.odm.utils.general import init_beanie
 from beanie.odm.documents import Document
 
-__version__ = "1.8.8"
+__version__ = "1.8.9"
 __all__ = [
     # ODM
     "Document",

--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -19,7 +19,7 @@ from beanie.odm.fields import (
 from beanie.odm.utils.general import init_beanie
 from beanie.odm.documents import Document
 
-__version__ = "1.8.11"
+__version__ = "1.8.12"
 __all__ = [
     # ODM
     "Document",

--- a/beanie/odm/bulk.py
+++ b/beanie/odm/bulk.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List, Optional, Union, Type
+from typing import Dict, Any, List, Optional, Union, Type, Mapping
 
 from pydantic import BaseModel
 from pymongo import (
@@ -20,7 +20,7 @@ class Operation(BaseModel):
         Type[UpdateOne],
         Type[UpdateMany],
     ]
-    first_query: Dict[str, Any]
+    first_query: Mapping[str, Any]
     second_query: Optional[Dict[str, Any]] = None
     object_class: Type
 

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -1129,6 +1129,7 @@ class Document(BaseModel, UpdateMethods):
         exclude: Union["AbstractSetIntStr", "MappingIntStrAny"] = None,
         by_alias: bool = False,
         skip_defaults: bool = None,
+        exclude_hidden: bool = True,
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
@@ -1137,8 +1138,8 @@ class Document(BaseModel, UpdateMethods):
         Overriding of the respective method from Pydantic
         Hides fields, marked as "hidden
         """
-        if exclude is None:
-            exclude = self._hidden_fields
+        if exclude_hidden:
+            exclude = self._hidden_fields if exclude is None else {*self._hidden_fields, *exclude}
         return super().dict(
             include=include,
             exclude=exclude,

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -1,6 +1,6 @@
 import asyncio
 import inspect
-from typing import ClassVar
+from typing import ClassVar, AbstractSet
 from typing import (
     Dict,
     Optional,
@@ -1143,7 +1143,12 @@ class Document(BaseModel, UpdateMethods):
         Hides fields, marked as "hidden
         """
         if exclude_hidden:
-            exclude = self._hidden_fields if not exclude else {*self._hidden_fields, *exclude}
+            if isinstance(exclude, AbstractSet):
+                exclude = {*self._hidden_fields, *exclude}
+            elif isinstance(exclude, Mapping):
+                exclude = dict({k: True for k in self._hidden_fields}, **exclude)
+            elif exclude is None:
+                exclude = self._hidden_fields
         return super().dict(
             include=include,
             exclude=exclude,

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -1146,7 +1146,7 @@ class Document(BaseModel, UpdateMethods):
             if isinstance(exclude, AbstractSet):
                 exclude = {*self._hidden_fields, *exclude}
             elif isinstance(exclude, Mapping):
-                exclude = dict({k: True for k in self._hidden_fields}, **exclude)
+                exclude = dict({k: True for k in self._hidden_fields}, **exclude)  # type: ignore
             elif exclude is None:
                 exclude = self._hidden_fields
         return super().dict(

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -1139,7 +1139,7 @@ class Document(BaseModel, UpdateMethods):
         Hides fields, marked as "hidden
         """
         if exclude_hidden:
-            exclude = self._hidden_fields if exclude is None else {*self._hidden_fields, *exclude}
+            exclude = self._hidden_fields if not exclude else {*self._hidden_fields, *exclude}
         return super().dict(
             include=include,
             exclude=exclude,

--- a/beanie/odm/settings/model.py
+++ b/beanie/odm/settings/model.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 
 
 class ModelSettings(BaseModel):
-    projection: Optional[Dict[str, Any]]
+    projection: Optional[Dict[str, Any]] = None
     use_state_management: bool = False
     validate_on_save: bool = False
     use_revision: bool = False

--- a/beanie/odm/utils/relations.py
+++ b/beanie/odm/utils/relations.py
@@ -28,7 +28,7 @@ def detect_link(field: ModelField) -> Optional[LinkInfo]:
         )
     if (
         inspect.isclass(get_origin(field.outer_type_))
-        and issubclass(get_origin(field.outer_type_), list)
+        and issubclass(get_origin(field.outer_type_), list)  # type: ignore
         and len(field.sub_fields) == 1  # type: ignore
     ):
         internal_field = field.sub_fields[0]  # type: ignore

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 Beanie project changes
 
+## [1.8.9] - 2021-12-23
+
+### Improvement
+
+- Deep search of updates for the `save_changes()` method
+
+### Kudos
+
+- Thanks, [Tigran Khazhakyan](https://github.com/tigrankh) for the deep search algo here
+
 ## [1.8.8] - 2021-12-17
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -630,3 +630,5 @@ how specific type should be presented in the database
 [1.8.7]: https://pypi.org/project/beanie/1.8.7
 
 [1.8.8]: https://pypi.org/project/beanie/1.8.8
+
+[1.8.9]: https://pypi.org/project/beanie/1.8.9

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,18 @@
 
 Beanie project changes
 
+## [1.8.12] - 2022-01-06
+
+### Improvement
+
+- Add exclude_hidden to dict() to be able to keep hidden fields hidden when the exclude parameter set
+
+### Implementation
+
+- Author - [Yallxe](https://github.com/yallxe)
+- PR - <https://github.com/roman-right/beanie/pull/178>
+
+
 ## [1.8.11] - 2021-12-30
 
 ### Improvement
@@ -645,6 +657,8 @@ how specific type should be presented in the database
 
 [1.8.9]: https://pypi.org/project/beanie/1.8.9
 
-[1.8.9]: https://pypi.org/project/beanie/1.8.10
+[1.8.10]: https://pypi.org/project/beanie/1.8.10
 
-[1.8.9]: https://pypi.org/project/beanie/1.8.11
+[1.8.11]: https://pypi.org/project/beanie/1.8.11
+
+[1.8.12]: https://pypi.org/project/beanie/1.8.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beanie"
-version = "1.8.8"
+version = "1.8.9"
 description = "Asynchronous Python ODM for MongoDB"
 authors = ["Roman <roman-right@protonmail.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-pydantic = ">=1.7.4,<1.8 || >=1.8.2"
+pydantic = ">=1.7.4,<1.8 || >=1.9.0"
 motor = "^2.5"
 click = ">=7"
 toml = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beanie"
-version = "1.8.11"
+version = "1.8.12"
 description = "Asynchronous Python ODM for MongoDB"
 authors = ["Roman <roman-right@protonmail.com>"]
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-pydantic = ">=1.7.4,<1.8 || >=1.9.0"
+pydantic = ">=1.9.0"
 motor = "^2.5"
 click = ">=7"
 toml = "*"

--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -167,6 +167,7 @@ def document_not_inserted():
     return DocumentTestModel(
         test_int=42,
         test_list=[SubDocument(test_str="foo"), SubDocument(test_str="bar")],
+        test_doc=SubDocument(test_str="foobar"),
         test_str="kipasa",
     )
 
@@ -183,6 +184,7 @@ def documents_not_inserted():
                     SubDocument(test_str="foo"),
                     SubDocument(test_str="bar"),
                 ],
+                test_doc=SubDocument(test_str="foobar"),
                 test_str="kipasa" if test_str is None else test_str,
             )
             for i in range(number)

--- a/tests/odm/documents/test_init.py
+++ b/tests/odm/documents/test_init.py
@@ -204,5 +204,6 @@ async def test_projection():
         "test_int": 1,
         "test_list": 1,
         "test_str": 1,
+        'test_doc': 1,
         "revision_id": 1,
     }

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -57,11 +57,13 @@ class Sample(Document):
 
 class SubDocument(BaseModel):
     test_str: str
+    test_int: int = 42
 
 
 class DocumentTestModel(Document):
     test_int: int
-    test_list: List[SubDocument]
+    test_list: List[SubDocument] = Field(hidden=True)
+    test_doc: SubDocument
     test_str: str
 
     class Settings:

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -206,9 +206,15 @@ class InheritedDocumentWithActions(DocumentWithActions):
     ...
 
 
+class InternalDoc(BaseModel):
+    num: int = 100
+    string: str = "test"
+
+
 class DocumentWithTurnedOnStateManagement(Document):
     num_1: int
     num_2: int
+    internal: InternalDoc
 
     class Settings:
         use_state_management = True

--- a/tests/odm/test_fields.py
+++ b/tests/odm/test_fields.py
@@ -1,10 +1,9 @@
 import datetime
 from pathlib import Path
-from typing import Union, Mapping, AbstractSet
+from typing import Mapping, AbstractSet
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from beanie import Document
 from beanie.odm.fields import PydanticObjectId
 from beanie.odm.utils.dump import get_dict
 from beanie.odm.utils.encoder import Encoder

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.8.8"
+    assert __version__ == "1.8.9"

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.8.11"
+    assert __version__ == "1.8.12"


### PR DESCRIPTION
Previously, when exclude param was provided, hidden fields were not excluded. This commit should fix this issue.

Still, if somebody do not want to exclude hidden fields, he can use `.dict(exclude_hidden=False)`, then, only fields `exclude` will work.