### PR TITLE
Feature/skip actions

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -22,7 +22,7 @@ from beanie.odm.settings.timeseries import TimeSeriesConfig, Granularity
 from beanie.odm.utils.general import init_beanie
 from beanie.odm.documents import Document
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 __all__ = [
     # ODM
     "Document",

--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -7,6 +7,8 @@ from beanie.odm.actions import (
     Replace,
     SaveChanges,
     ValidateOnSave,
+    Before,
+    After,
 )
 from beanie.odm.bulk import BulkWriter
 from beanie.odm.fields import (
@@ -36,6 +38,8 @@ __all__ = [
     "Replace",
     "SaveChanges",
     "ValidateOnSave",
+    "Before",
+    "After",
     # Bulk Write
     "BulkWriter",
     # Migrations

--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -26,6 +26,10 @@ class ActionDirections(str, Enum):  # TODO think about this name
     AFTER = "AFTER"
 
 
+Before = ActionDirections.BEFORE
+After = ActionDirections.AFTER
+
+
 class ActionRegistry:
     _actions: Dict[Type, Any] = {}
 
@@ -183,6 +187,8 @@ def wrap_with_actions(event_type: EventTypes):
             skip_actions: Optional[List[Union[ActionDirections, str]]] = None,
             **kwargs,
         ):
+            # Forwards the parameter
+            kwargs["skip_actions"] = skip_actions
 
             if skip_actions is None:
                 skip_actions = set()

--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 from enum import Enum
 from functools import wraps
-from typing import Callable, List, Union, Dict, TYPE_CHECKING, Any, Type, Set, Optional
+from typing import Callable, List, Union, Dict, TYPE_CHECKING, Any, Type, Optional
 
 if TYPE_CHECKING:
     from beanie.odm.documents import Document
@@ -94,7 +94,7 @@ class ActionRegistry:
         instance: "Document",
         event_type: EventTypes,
         action_direction: ActionDirections,
-        exclude: Set[Union[ActionDirections, str]],
+        exclude: List[Union[ActionDirections, str]],
     ):
         """
         Run actions
@@ -191,9 +191,7 @@ def wrap_with_actions(event_type: EventTypes):
             kwargs["skip_actions"] = skip_actions
 
             if skip_actions is None:
-                skip_actions = set()
-            else:
-                skip_actions = set(skip_actions)
+                skip_actions = []
 
             await ActionRegistry.run_actions(
                 self,

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -156,6 +156,7 @@ class Document(BaseModel, UpdateMethods):
         *,
         link_rule: WriteRules = WriteRules.DO_NOTHING,
         session: Optional[ClientSession] = None,
+        **kwargs,
     ) -> DocType:
         """
         Insert the document (self) to the collection
@@ -599,6 +600,7 @@ class Document(BaseModel, UpdateMethods):
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         link_rule: WriteRules = WriteRules.DO_NOTHING,
+        **kwargs,
     ) -> DocType:
         """
         Fully update the document in the database
@@ -703,6 +705,7 @@ class Document(BaseModel, UpdateMethods):
         ignore_revision: bool = False,
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
+        **kwargs,
     ) -> None:
         """
         Save changes.
@@ -1211,7 +1214,7 @@ class Document(BaseModel, UpdateMethods):
         )
 
     @wrap_with_actions(event_type=EventTypes.VALIDATE_ON_SAVE)
-    async def validate_self(self):
+    async def validate_self(self, *args, **kwargs):
         # TODO it can be sync, but needs some actions controller improvements
         if self.get_settings().model_settings.validate_on_save:
             self.parse_obj(self)

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -665,6 +665,7 @@ class Document(BaseModel, UpdateMethods):
         self: DocType,
         session: Optional[ClientSession] = None,
         link_rule: WriteRules = WriteRules.DO_NOTHING,
+        **kwargs,
     ) -> DocType:
         """
         Update an existing model in the database or insert it if it does not yet exist.
@@ -693,9 +694,9 @@ class Document(BaseModel, UpdateMethods):
                                 )
 
         try:
-            return await self.replace(session=session)
+            return await self.replace(session=session, **kwargs)
         except (ValueError, DocumentNotFound):
-            return await self.insert(session=session)
+            return await self.insert(session=session, **kwargs)
 
     @saved_state_needed
     @wrap_with_actions(EventTypes.SAVE_CHANGES)

--- a/beanie/odm/utils/self_validation.py
+++ b/beanie/odm/utils/self_validation.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 def validate_self_before(f: Callable):
     @wraps(f)
     async def wrapper(self: "DocType", *args, **kwargs):
-        await self.validate_self()
+        await self.validate_self(*args, **kwargs)
         return await f(self, *args, **kwargs)
 
     return wrapper

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,17 @@
 # Changelog
 
-Beanie project 
+Beanie project
+
+## [1.10.1] - 2022-02-24
+
+### Improvement
+
+- Skip actions
+
+### Implementation
+
+- Author - [Paul Renvoisé](https://github.com/paul-finary)
+- PR <https://github.com/roman-right/beanie/pull/218>
 
 ## [1.10.0] - 2022-02-24
 

--- a/docs/tutorial/actions.md
+++ b/docs/tutorial/actions.md
@@ -1,13 +1,22 @@
 # Event-based actions
 
-You can register methods as pre- or post- actions for document events like `insert`, `replace` and etc.
+You can register methods as pre- or post- actions for document events.
 
 Currently supported events:
-
 - Insert
 - Replace
 - SaveChanges
 - ValidateOnSave
+
+Currently supported directions:
+- Before
+- After
+
+Current operations creating events:
+- `insert()` and `save()` for Insert
+- `replace()` and `save()` for Replace
+- `save_changes()` for SaveChanges
+- `insert()`, `replace()`, `save_changes()`, and `save()` for ValidateOnSave
 
 To register an action you can use `@before_event` and `@after_event` decorators respectively.
 
@@ -41,7 +50,7 @@ class Sample(Document):
         self.name = self.name.capitalize()
 ```
 
-This will capitalize the `name` field value before each document insert and replace
+This will capitalize the `name` field value before each document insert and replace.
 
 And sync and async methods could work as actions.
 
@@ -55,4 +64,38 @@ class Sample(Document):
     @after_event([Insert, Replace])
     async def send_callback(self):
         await client.send(self.id)
+```
+
+Actions can be selectively skipped by passing the parameter `skip_actions` when calling
+the operations that trigger events. `skip_actions` accepts a list of directions and action names.
+
+```python
+from beanie import Insert, Replace, Before, After
+
+class Sample(Document):
+    num: int
+    name: str
+
+    @before_event(Insert)
+    def capitalize_name(self):
+        self.name = self.name.capitalize()
+
+    @before_event(Replace)
+    def redact_name(self):
+        self.name = "[REDACTED]"
+
+    @after_event(Replace)
+    def num_change(self):
+        self.num -= 1
+
+sample = Sample()
+
+# capitalize_name will not be executed
+await sample.insert(skip_actions=['capitalize_name'])
+
+# num_change will not be executed
+await sample.replace(skip_actions=[After])
+
+# redact_name and num_change will not be executed
+await sample.replace(skip_actions[Before, 'num_change'])
 ```

--- a/docs/tutorial/state_management.md
+++ b/docs/tutorial/state_management.md
@@ -44,7 +44,8 @@ i = Item(name="Test", attributes={"attribute_1": 1.0, "attribute_2": 2.0})
 await i.insert()
 i.attributes = {"attribute_1": 1.0}
 await i.save_changes()
-# Changes will consist of: {"attributes.attribute": 1.0}
+# Changes will consist of: {"attributes.attribute_1": 1.0}
+# Keeping attribute_2
 ```
 
 However, there's some cases where you want to replace the whole object when one of its attributes changed.

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -49,7 +49,7 @@ renderer:
     - title: Getting started
       source: docs/getting-started.md
     - title: Tutorial
-      children: 
+      children:
         - title: Defining a document
           source: docs/tutorial/defining-a-document.md
         - title: Initialization
@@ -72,7 +72,7 @@ renderer:
           source: docs/tutorial/cache.md
         - title: Revision
           source: docs/tutorial/revision.md
-        - title: Save changes
+        - title: State Management
           source: docs/tutorial/state_management.md
         - title: On save validation
           source: docs/tutorial/on_save_validation.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beanie"
-version = "1.10.0"
+version = "1.10.1"
 description = "Asynchronous Python ODM for MongoDB"
 authors = ["Roman <roman-right@protonmail.com>"]
 license = "Apache-2.0"

--- a/tests/odm/documents/test_validation_on_save.py
+++ b/tests/odm/documents/test_validation_on_save.py
@@ -31,3 +31,9 @@ async def test_validate_on_save_action():
     doc = DocumentWithValidationOnSave(num_1=1, num_2=2)
     await doc.insert()
     assert doc.num_2 == 3
+
+
+async def test_validate_on_save_skip_action():
+    doc = DocumentWithValidationOnSave(num_1=1, num_2=2)
+    await doc.insert(skip_actions=['num_2_plus_1'])
+    assert doc.num_2 == 2

--- a/tests/odm/test_actions.py
+++ b/tests/odm/test_actions.py
@@ -1,23 +1,85 @@
 import pytest
 
+from beanie.odm.actions import ActionDirections
+
 from tests.odm.models import DocumentWithActions, InheritedDocumentWithActions
+
+
+# @pytest.mark.parametrize(
+#     "doc_class", [DocumentWithActions, InheritedDocumentWithActions]
+# )
+# async def test_actions_insert_replace(doc_class):
+#     test_name = "test_name"
+#     sample = doc_class(name=test_name)
+
+#     # TEST INSERT
+#     await sample.insert()
+#     assert sample.name != test_name
+#     assert sample.name == test_name.capitalize()
+#     assert sample.num_1 == 1
+#     assert sample.num_2 == 9
+
+#     # TEST REPLACE
+#     await sample.replace()
+#     assert sample.num_1 == 2
+#     assert sample.num_3 == 99
 
 
 @pytest.mark.parametrize(
     "doc_class", [DocumentWithActions, InheritedDocumentWithActions]
 )
-async def test_actions_insert_replace(doc_class):
-    test_name = "test_name"
+async def test_actions_insert(doc_class):
+    test_name = f"test_actions_insert_{doc_class}"
     sample = doc_class(name=test_name)
 
-    # TEST INSERT
     await sample.insert()
     assert sample.name != test_name
     assert sample.name == test_name.capitalize()
     assert sample.num_1 == 1
     assert sample.num_2 == 9
 
-    # TEST REPLACE
+
+@pytest.mark.parametrize(
+    "doc_class", [DocumentWithActions, InheritedDocumentWithActions]
+)
+async def test_actions_replace(doc_class):
+    test_name = f"test_actions_replace_{doc_class}"
+    sample = doc_class(name=test_name)
+
+    await sample.insert()
+
     await sample.replace()
     assert sample.num_1 == 2
     assert sample.num_3 == 99
+
+
+@pytest.mark.parametrize(
+    "doc_class", [DocumentWithActions, InheritedDocumentWithActions]
+)
+async def test_skip_actions_insert(doc_class):
+    test_name = f"test_skip_actions_insert_{doc_class}"
+    sample = doc_class(name=test_name)
+
+    await sample.insert(skip_actions=[ActionDirections.AFTER, 'capitalize_name'])
+    # capitalize_name has been skipped
+    assert sample.name == test_name
+    # add_one has not been skipped
+    assert sample.num_1 == 1
+    # num_2_change has been skipped
+    assert sample.num_2 == 10
+
+
+@pytest.mark.parametrize(
+    "doc_class", [DocumentWithActions, InheritedDocumentWithActions]
+)
+async def test_skip_actions_replace(doc_class):
+    test_name = f"test_skip_actions_replace{doc_class}"
+    sample = doc_class(name=test_name)
+
+    await sample.insert()
+
+    await sample.replace(skip_actions=[ActionDirections.BEFORE, 'num_3_change'])
+    # add_one has been skipped
+    assert sample.num_1 == 1
+    # num_3_change has been skipped
+    assert sample.num_3 == 100

--- a/tests/odm/test_actions.py
+++ b/tests/odm/test_actions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from beanie.odm.actions import Before, After
+from beanie import Before, After
 
 from tests.odm.models import DocumentWithActions, InheritedDocumentWithActions
 

--- a/tests/odm/test_actions.py
+++ b/tests/odm/test_actions.py
@@ -1,28 +1,8 @@
 import pytest
 
-from beanie.odm.actions import ActionDirections
+from beanie.odm.actions import Before, After
 
 from tests.odm.models import DocumentWithActions, InheritedDocumentWithActions
-
-
-# @pytest.mark.parametrize(
-#     "doc_class", [DocumentWithActions, InheritedDocumentWithActions]
-# )
-# async def test_actions_insert_replace(doc_class):
-#     test_name = "test_name"
-#     sample = doc_class(name=test_name)
-
-#     # TEST INSERT
-#     await sample.insert()
-#     assert sample.name != test_name
-#     assert sample.name == test_name.capitalize()
-#     assert sample.num_1 == 1
-#     assert sample.num_2 == 9
-
-#     # TEST REPLACE
-#     await sample.replace()
-#     assert sample.num_1 == 2
-#     assert sample.num_3 == 99
 
 
 @pytest.mark.parametrize(
@@ -60,7 +40,7 @@ async def test_skip_actions_insert(doc_class):
     test_name = f"test_skip_actions_insert_{doc_class}"
     sample = doc_class(name=test_name)
 
-    await sample.insert(skip_actions=[ActionDirections.AFTER, 'capitalize_name'])
+    await sample.insert(skip_actions=[After, 'capitalize_name'])
     # capitalize_name has been skipped
     assert sample.name == test_name
     # add_one has not been skipped
@@ -78,7 +58,7 @@ async def test_skip_actions_replace(doc_class):
 
     await sample.insert()
 
-    await sample.replace(skip_actions=[ActionDirections.BEFORE, 'num_3_change'])
+    await sample.replace(skip_actions=[Before, 'num_3_change'])
     # add_one has been skipped
     assert sample.num_1 == 1
     # num_3_change has been skipped

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.10.0"
+    assert __version__ == "1.10.1"


### PR DESCRIPTION
This PR adds a way to skip specific actions when doing operations that trigger events.

Closes #216.

Changes:
- Added a kwarg `skip_actions` to all methods that trigger an action event (save, insert, replace, save_changes, validate_self):
    - Accepts `Optional[List[Union[ActionDirections, str]]]`: either an ActionDirection, or the name of an action
- Exposed ActionDirections:
    - Before
    - After
- Added tests for action events
- Added doc for `skip_actions`
- Fixed the doc for state_management (my previous PR)