### PR TITLE
Allow custom MigrationNode for `build`

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -23,7 +23,7 @@ from beanie.odm.settings.timeseries import TimeSeriesConfig, Granularity
 from beanie.odm.utils.general import init_beanie
 from beanie.odm.documents import Document
 
-__version__ = "1.10.3"
+__version__ = "1.10.4"
 __all__ = [
     # ODM
     "Document",

--- a/beanie/migrations/runner.py
+++ b/beanie/migrations/runner.py
@@ -176,7 +176,7 @@ class MigrationNode:
         )
         current_migration = await MigrationLog.find_one({"is_current": True})
 
-        root_migration_node = MigrationNode("root")
+        root_migration_node = cls("root")
         prev_migration_node = root_migration_node
 
         for name in names:
@@ -185,7 +185,7 @@ class MigrationNode:
             ).load_module((path / name).stem)
             forward_class = getattr(module, "Forward", None)
             backward_class = getattr(module, "Backward", None)
-            migration_node = MigrationNode(
+            migration_node = cls(
                 name=name,
                 prev_migration=prev_migration_node,
                 forward_class=forward_class,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,18 @@
 
 Beanie project
 
-## [1.10.2] - 2022-02-24
+## [1.10.4] - 2022-02-24
+
+### Improvement
+
+- Allow custom MigrationNode for build
+
+### Implementation
+
+- Author - [amos402](https://github.com/amos402)
+- PR <https://github.com/roman-right/beanie/pull/234>
+
+## [1.10.3] - 2022-02-29
 
 ### Improvement
 
@@ -12,7 +23,7 @@ Beanie project
 
 - ISSUE <https://github.com/roman-right/beanie/issues/225>
 
-## [1.10.2] - 2022-02-24
+## [1.10.2] - 2022-02-28
 
 ### Improvement
 
@@ -763,3 +774,5 @@ how specific type should be presented in the database
 [1.10.2]: https://pypi.org/project/beanie/1.10.2
 
 [1.10.3]: https://pypi.org/project/beanie/1.10.3
+
+[1.10.4]: https://pypi.org/project/beanie/1.10.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beanie"
-version = "1.10.3"
+version = "1.10.4"
 description = "Asynchronous Python ODM for MongoDB"
 authors = ["Roman <roman-right@protonmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.10.3"
+    assert __version__ == "1.10.4"


### PR DESCRIPTION
It's simple, `MigrationNode.build` uses hardcoded `MigrationNode` to create a node object, it forbid its subclasses to reuse this method.
