### PR TITLE
Avoid creating redundant query object

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -23,7 +23,7 @@ from beanie.odm.settings.timeseries import TimeSeriesConfig, Granularity
 from beanie.odm.utils.general import init_beanie
 from beanie.odm.documents import Document
 
-__version__ = "1.10.4"
+__version__ = "1.10.5"
 __all__ = [
     # ODM
     "Document",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,18 @@
 
 Beanie project
 
-## [1.10.4] - 2022-02-24
+## [1.10.5] - 2022-04-11
+
+### Improvement
+
+- Avoid creating redundant query object
+
+### Implementation
+
+- Author - [amos402](https://github.com/amos402)
+- PR <https://github.com/roman-right/beanie/pull/235>
+
+## [1.10.4] - 2022-03-24
 
 ### Improvement
 
@@ -776,3 +787,5 @@ how specific type should be presented in the database
 [1.10.3]: https://pypi.org/project/beanie/1.10.3
 
 [1.10.4]: https://pypi.org/project/beanie/1.10.4
+
+[1.10.5]: https://pypi.org/project/beanie/1.10.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beanie"
-version = "1.10.4"
+version = "1.10.5"
 description = "Asynchronous Python ODM for MongoDB"
 authors = ["Roman <roman-right@protonmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.10.4"
+    assert __version__ == "1.10.5"


### PR DESCRIPTION
Since `motor_cursor` would create a query object every time when it is accessed, this change it's for preventing that meaningless object allocation.
