### PR TITLE
Encode dictionary keys as strings

### DIFF
--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -119,8 +119,7 @@ class Encoder:
         """
         Dictionary case
         """
-        for key, value in obj.items():
-            obj[key] = self._encode(value)
+        obj = {str(key): self._encode(value) for key, value in obj.items()}
         return obj
 
     def encode_iterable(self, obj):


### PR DESCRIPTION
This works around a difference between json and bson where the bson encoder doesn't automatically change dictionary keys to be strings.