### PR TITLE
Classes with Pydantic `extra=Extra.allow` config can read all fields

### DIFF
--- a/beanie/odm/utils/projection.py
+++ b/beanie/odm/utils/projection.py
@@ -19,7 +19,12 @@ def get_projection(
         settings = getattr(model, "Settings")
         if hasattr(settings, "projection"):
             return getattr(settings, "projection")
+
+    if getattr(model.Config, "extra", None) == "allow":
+        return None
+
     document_projection: Dict[str, int] = {}
+
     for name, field in model.__fields__.items():
         document_projection[field.alias] = 1
     return document_projection

--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -25,6 +25,7 @@ from tests.odm.models import (
     DocumentWithValidationOnSave,
     DocumentWithRevisionTurnedOn,
     DocumentWithPydanticConfig,
+    DocumentWithExtras,
     House,
     Window,
     Door,
@@ -132,6 +133,7 @@ async def session(cli, loop):
 @pytest.fixture(autouse=True)
 async def init(loop, db):
     models = [
+        DocumentWithExtras,
         DocumentWithPydanticConfig,
         DocumentTestModel,
         DocumentTestModelWithCustomCollectionName,

--- a/tests/odm/documents/test_pydantic_extras.py
+++ b/tests/odm/documents/test_pydantic_extras.py
@@ -1,0 +1,34 @@
+import pytest
+
+from tests.odm.models import (
+    DocumentWithExtras,
+    DocumentWithPydanticConfig,
+    DocumentWithExtrasKw,
+)
+
+
+async def test_pydantic_extras():
+    doc = DocumentWithExtras(num_1=2)
+    doc.extra_value = "foo"
+    await doc.save()
+
+    loaded_doc = await DocumentWithExtras.get(doc.id)
+
+    assert loaded_doc.extra_value == "foo"
+
+
+@pytest.mark.skip(reason="setting extra to allow via class kwargs not working")
+async def test_pydantic_extras_kw():
+    doc = DocumentWithExtrasKw(num_1=2)
+    doc.extra_value = "foo"
+    await doc.save()
+
+    loaded_doc = await DocumentWithExtras.get(doc.id)
+
+    assert loaded_doc.extra_value == "foo"
+
+
+async def test_fail_with_no_extras():
+    doc = DocumentWithPydanticConfig(num_1=2)
+    with pytest.raises(ValueError):
+        doc.extra_value = "foo"

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Set, Tuple, Union
 from uuid import UUID, uuid4
 
 import pymongo
-from pydantic import SecretBytes, SecretStr
+from pydantic import SecretBytes, SecretStr, Extra
 from pydantic.color import Color
 from pydantic import BaseModel, Field
 from pymongo import IndexModel
@@ -305,6 +305,17 @@ class DocumentWithPydanticConfig(Document):
 
     class Config(Document.Config):
         validate_assignment = True
+
+
+class DocumentWithExtras(Document):
+    num_1: int
+
+    class Config(Document.Config):
+        extra = Extra.allow
+
+
+class DocumentWithExtrasKw(Document, extra=Extra.allow):
+    num_1: int
 
 
 class Window(Document):


### PR DESCRIPTION
Closes #244 

As mentioned in the issue, Pydantic lets you set `extra=Extra.allow` to allow models to have extra fields which are not validated. Currently settings this while using Beanie will save the field to Mongodb, but it won't read it back in afterwards.

Poked around the code a bit and this is because the default projection is based on the fields in the model, so it anything not in the model will get discarded.

I added a check to see if `model.Config.extra == "Allow"`. If it is then `get_projection` returns `None`, so all fields (which aren't hidden) will be returned, even if they're not in the model.

Also added some tests for this to check that (1) it works and that (2) the default behavior of ignoring extra fields is preserved.

Few things to note:

- You can also set this configuration with a keyword argument in the class (`class Thing(Document, extra=Extra.allow)`) but this doesn't work right now, not sure why and didn't look into it, but it's worth mentioning somewhere
- Speaking of mentioning somewhere, I want to add this to the docs, where would the best place for that be?