### PR TITLE
New feature - Check for unique fields

### DIFF
--- a/beanie/exceptions.py
+++ b/beanie/exceptions.py
@@ -64,3 +64,7 @@ class UnionDocNotInited(Exception):
 
 class DocWasNotRegisteredInUnionClass(Exception):
     pass
+
+
+class UniqueFieldExists(Exception):
+    pass

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -67,6 +67,7 @@ from beanie.odm.models import (
     InspectionResult,
     InspectionStatuses,
     InspectionError,
+    UniqueFieldsModel,
 )
 from beanie.odm.operators.find.comparison import In
 from beanie.odm.queries.update import UpdateMany
@@ -95,6 +96,7 @@ class Document(
     FindInterface,
     AggregateInterface,
     OtherGettersInterface,
+    UniqueFieldsModel,
 ):
     """
     Document Mapping class.

--- a/beanie/odm/interfaces/getters.py
+++ b/beanie/odm/interfaces/getters.py
@@ -26,3 +26,7 @@ class OtherGettersInterface:
     @classmethod
     def get_link_fields(cls):
         return None
+
+    @classmethod
+    def get_unique_fields(cls):
+        return cls.get_settings().unique_fields

--- a/beanie/odm/models.py
+++ b/beanie/odm/models.py
@@ -2,8 +2,14 @@ from typing import List
 
 from pydantic import BaseModel
 
+from beanie.exceptions import UniqueFieldExists
 from beanie.odm.enums import InspectionStatuses
 from beanie.odm.fields import PydanticObjectId
+from beanie.odm.actions import (
+    Insert,
+    Replace,
+    before_event,
+)
 
 
 class InspectionError(BaseModel):
@@ -22,3 +28,17 @@ class InspectionResult(BaseModel):
 
     status: InspectionStatuses = InspectionStatuses.OK
     errors: List[InspectionError] = []
+
+
+class UniqueFieldsModel: # noqa
+    @before_event([Insert, Replace])
+    async def check_for_unique_fields(self):
+        unique_fields = self.get_unique_fields()
+        if unique_fields:
+            for field in unique_fields:
+                try:
+                    if await self.find_one({field: getattr(self, field)}):
+                        raise UniqueFieldExists
+                    continue
+                except AttributeError:
+                    pass

--- a/beanie/odm/settings/base.py
+++ b/beanie/odm/settings/base.py
@@ -19,5 +19,7 @@ class ItemSettings(BaseModel):
 
     union_doc: Optional[Type] = None
 
+    unique_fields: Optional[list] = None
+
     class Config:
         arbitrary_types_allowed = True


### PR DESCRIPTION
Hi. I needed to check the duplicate fields(unique fields) in the database. I added unique_fields to ItemSettings to solve this.
Sample:
```
class User(Document):
    first_name: str | None = None
    last_name: str | None = None
    username: str
    national_code: str

    class Settings:
        name = "users"
        unique_fields = ['username', 'national_code'] # list of your model unique fields
```
If each is a duplicate in the database, It will raise UniqueFieldExists exception.