### PR TITLE
Turn the caching system into an interface to support different caching strategies

### DIFF
--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -10,6 +10,7 @@ jobs:
         poetry-version: [ 1.1.4 ]
         mongodb-version: [ 4.4, 5.0 ]
         pydantic-version: [1.9.0]
+        redis-version: [6.2]
         os: [ ubuntu-18.04 ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -22,6 +23,10 @@ jobs:
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
           mongodb-replica-set: test-rs
+      - name: Setup Redis
+        uses: zhulik/redis-action@1.1.0
+        with:
+          redis version:  ${{ matrix.redis-version }}
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
@@ -32,3 +37,4 @@ jobs:
         run: poetry add pydantic==${{ matrix.pydantic-version }}
       - name: run tests
         run: poetry run pytest
+      

--- a/beanie/odm/cache.py
+++ b/beanie/odm/cache.py
@@ -127,8 +127,6 @@ class RedisCache(Cache):
         return data if data else None
 
     def set(self, key, value) -> None:
-        if not value:
-            return
         value = self._serialize(value)
         key = self._get_key(key)
         self.redis_client.set(key, value, ex=self.ttl)

--- a/beanie/odm/cache.py
+++ b/beanie/odm/cache.py
@@ -25,6 +25,10 @@ class Cache(abc.ABC):
     def get(self, key: str) -> Optional[CachedItem]:
         ...
 
+    @abc.abstractmethod
+    def invalidate(self) -> None:
+        ...
+
     @staticmethod
     def create_key(*args):
         return str(args)  # TODO think about this
@@ -56,6 +60,9 @@ class LRUCache(Cache):
             if len(self.cache) >= self.capacity:
                 self.cache.popitem(last=False)
         self.cache[key] = CachedItem(value=value)
+
+    def invalidate(self) -> None:
+        self.cache.clear()
 
 
 class RedisCache(Cache):
@@ -125,3 +132,6 @@ class RedisCache(Cache):
         value = self._serialize(value)
         key = self._get_key(key)
         self.redis_client.set(key, value, ex=self.ttl)
+
+    def invalidate(self) -> None:
+        self.redis_client.flushdb()

--- a/beanie/odm/cache.py
+++ b/beanie/odm/cache.py
@@ -1,3 +1,4 @@
+import abc
 import collections
 import datetime
 from datetime import timedelta
@@ -13,7 +14,21 @@ class CachedItem(BaseModel):
     value: Any
 
 
-class LRUCache:
+class Cache(abc.ABC):
+    @abc.abstractmethod
+    def set(self, key: str, value: Any) -> None:
+        ...
+
+    @abc.abstractmethod
+    def get(self, key: str) -> Optional[CachedItem]:
+        ...
+
+    @staticmethod
+    def create_key(*args):
+        return str(args)  # TODO think about this
+
+
+class LRUCache(Cache):
     def __init__(self, capacity: int, expiration_time: timedelta):
         self.capacity: int = capacity
         self.expiration_time: timedelta = expiration_time
@@ -40,6 +55,3 @@ class LRUCache:
                 self.cache.popitem(last=False)
         self.cache[key] = CachedItem(value=value)
 
-    @staticmethod
-    def create_key(*args):
-        return str(args)  # TODO think about this

--- a/beanie/odm/cache.py
+++ b/beanie/odm/cache.py
@@ -1,9 +1,11 @@
 import abc
 import collections
 import datetime
+import pickle
 from datetime import timedelta
-from typing import Any, Optional
+from typing import Any, Optional, Sequence, Union
 
+import msgpack
 from pydantic import BaseModel, Field
 
 
@@ -55,3 +57,71 @@ class LRUCache(Cache):
                 self.cache.popitem(last=False)
         self.cache[key] = CachedItem(value=value)
 
+
+class RedisCache(Cache):
+    def __init__(
+        self,
+        redis_client,
+        ttl: Optional[Union[int, timedelta]] = None,
+        key_prefix: str = "cache",
+        serializer=pickle,
+    ):
+        self.redis_client = redis_client
+        self.key_prefix = key_prefix
+        self.ttl = self._normalize_ttl(ttl)
+        self.serializer = serializer
+
+    def _normalize_object_ids(self, value):
+        if isinstance(value, dict):
+            if "_id" in value:
+                value["_id"] = str(value["_id"])
+        elif isinstance(value, Sequence):
+            for row in value:
+                self._normalize_object_ids(row)
+        return value
+
+    def _serialize(self, value):
+        if not value:
+            return None
+        if self.serializer is not pickle:
+            # Turn ObjectId to string for those serializer that can't
+            # serialize ObjectId, like: msgpack and json
+            value = self._normalize_object_ids(value)
+        return self.serializer.dumps(value)
+
+    def _deserialize(self, value):
+        try:
+            loaded = self.serializer.loads(value)
+            return loaded
+        except (
+            TypeError,
+            pickle.UnpicklingError,
+            UnicodeDecodeError,
+            msgpack.exceptions.UnpackException,
+            msgpack.exceptions.ExtraData,
+        ):
+            return None
+
+    def _get_key(self, key):
+        return f"{self.key_prefix}:{self.serializer.__name__}:{key}"
+
+    @staticmethod
+    def _normalize_ttl(ttl: Optional[Union[int, timedelta]]) -> Optional[int]:
+        if isinstance(ttl, timedelta):
+            return ttl.seconds
+        elif isinstance(ttl, int) and ttl >= 0:
+            return ttl
+        return None
+
+    def get(self, key) -> Optional[CachedItem]:
+        key = self._get_key(key)
+        redis_data = self.redis_client.get(key)
+        data = self._deserialize(redis_data)
+        return data if data else None
+
+    def set(self, key, value) -> None:
+        if not value:
+            return
+        value = self._serialize(value)
+        key = self._get_key(key)
+        self.redis_client.set(key, value, ex=self.ttl)

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -46,7 +46,7 @@ from beanie.odm.actions import (
     ActionDirections,
 )
 from beanie.odm.bulk import BulkWriter, Operation
-from beanie.odm.cache import LRUCache
+from beanie.odm.cache import Cache
 from beanie.odm.fields import (
     PydanticObjectId,
     ExpressionField,
@@ -121,7 +121,7 @@ class Document(
     _link_fields: ClassVar[Optional[Dict[str, LinkInfo]]] = None
 
     # Cache
-    _cache: ClassVar[Optional[LRUCache]] = None
+    _cache: ClassVar[Optional[Cache]] = None
 
     # Settings
     _document_settings: ClassVar[Optional[DocumentSettings]] = None
@@ -690,10 +690,7 @@ class Document(
         :return: None
         """
         if cls.get_settings().use_cache:
-            cls._cache = LRUCache(
-                capacity=cls.get_settings().cache_capacity,
-                expiration_time=cls.get_settings().cache_expiration_time,
-            )
+            cls._cache = cls.get_settings().cache_system
 
     @classmethod
     def init_fields(cls) -> None:

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -693,6 +693,17 @@ class Document(
             cls._cache = cls.get_settings().cache_system
 
     @classmethod
+    def invalidate_cache(cls) -> None:
+        """
+        Invalidate model's cache
+        :return: None
+        """
+        if cls.get_settings().use_cache and isinstance(
+            cls.get_settings().cache_system, Cache
+        ):
+            cls._cache.invalidate()  # type: ignore
+
+    @classmethod
     def init_fields(cls) -> None:
         """
         Init class fields
@@ -897,10 +908,12 @@ class Document(
 
     @classmethod
     async def distinct(
-            cls,
-            key: str,
-            filter: Optional[Mapping[str, Any]] = None,
-            session: Optional[ClientSession] = None,
-            **kwargs: Any
+        cls,
+        key: str,
+        filter: Optional[Mapping[str, Any]] = None,
+        session: Optional[ClientSession] = None,
+        **kwargs: Any,
     ) -> list:
-        return await cls.get_motor_collection().distinct(key, filter, session, **kwargs)
+        return await cls.get_motor_collection().distinct(
+            key, filter, session, **kwargs
+        )

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -689,7 +689,9 @@ class Document(
         Init model's cache
         :return: None
         """
-        if cls.get_settings().use_cache:
+        if cls.get_settings().use_cache and isinstance(
+            cls.get_settings().cache_system, Cache
+        ):
             cls._cache = cls.get_settings().cache_system
 
     @classmethod

--- a/beanie/odm/queries/aggregation.py
+++ b/beanie/odm/queries/aggregation.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from motor.core import AgnosticCommandCursor
 
-from beanie.odm.cache import LRUCache
+from beanie.odm.cache import Cache
 from beanie.odm.interfaces.session import SessionMethods
 from beanie.odm.queries.cursor import BaseCursorQuery
 from beanie.odm.utils.projection import get_projection
@@ -59,7 +59,7 @@ class AggregationQuery(
 
     @property
     def _cache_key(self) -> str:
-        return LRUCache.create_key(
+        return Cache.create_key(
             {
                 "type": "Aggregation",
                 "filter": self.find_query,

--- a/beanie/odm/queries/find.py
+++ b/beanie/odm/queries/find.py
@@ -24,7 +24,7 @@ from pymongo.results import UpdateResult
 from pymongo import ReplaceOne
 
 from beanie.exceptions import DocumentNotFound
-from beanie.odm.cache import LRUCache
+from beanie.odm.cache import Cache
 from beanie.odm.bulk import BulkWriter, Operation
 from beanie.odm.enums import SortDirection
 from beanie.odm.interfaces.aggregation_methods import AggregateMethods
@@ -557,7 +557,7 @@ class FindMany(
 
     @property
     def _cache_key(self) -> str:
-        return LRUCache.create_key(
+        return Cache.create_key(
             {
                 "type": "FindMany",
                 "filter": self.get_filter_query(),
@@ -865,7 +865,7 @@ class FindOne(FindQuery[FindQueryResultType]):
             self.document_model.get_settings().use_cache
             and self.ignore_cache is False
         ):
-            cache_key = LRUCache.create_key(
+            cache_key = Cache.create_key(
                 "FindOne",
                 self.get_filter_query(),
                 self.projection_model,

--- a/beanie/odm/settings/base.py
+++ b/beanie/odm/settings/base.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from typing import Optional, Dict, Any, Type
 
+from beanie.odm.cache import Cache, LRUCache
 from motor.motor_asyncio import AsyncIOMotorDatabase, AsyncIOMotorCollection
 from pydantic import BaseModel, Field
 
@@ -9,8 +10,9 @@ class ItemSettings(BaseModel):
     name: Optional[str]
 
     use_cache: bool = False
-    cache_capacity: int = 32
-    cache_expiration_time: timedelta = timedelta(minutes=10)
+    cache_system: Cache = LRUCache(
+        capacity=32, expiration_time=timedelta(minutes=10)
+    )
     bson_encoders: Dict[Any, Any] = Field(default_factory=dict)
     projection: Optional[Dict[str, Any]] = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ motor = "^2.5"
 click = ">=7"
 toml = "*"
 yarl = ">=1.6"
+redis = "^4.3.1"
+msgpack = "^1.0.3"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.3.0"

--- a/tests/odm/documents/test_bulk_write.py
+++ b/tests/odm/documents/test_bulk_write.py
@@ -22,6 +22,7 @@ async def test_insert(documents_not_inserted):
 
 async def test_update(documents, document_not_inserted):
     await documents(5)
+    DocumentTestModel.invalidate_cache()
     doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 0)
     doc.test_int = 100
     async with BulkWriter() as bulk_writer:
@@ -64,6 +65,7 @@ async def test_update(documents, document_not_inserted):
 
 async def test_delete(documents, document_not_inserted):
     await documents(5)
+    DocumentTestModel.invalidate_cache()
     doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 0)
     async with BulkWriter() as bulk_writer:
         await doc.delete(bulk_writer=bulk_writer)
@@ -79,6 +81,7 @@ async def test_delete(documents, document_not_inserted):
 
 async def test_replace(documents, document_not_inserted):
     await documents(5)
+    DocumentTestModel.invalidate_cache()
     doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 0)
     doc.test_int = 100
     async with BulkWriter() as bulk_writer:
@@ -103,6 +106,7 @@ async def test_replace(documents, document_not_inserted):
 
 async def test_upsert_find_many_not_found(documents, document_not_inserted):
     await documents(5)
+    DocumentTestModel.invalidate_cache()
     document_not_inserted.test_int = -10000
     async with BulkWriter() as bulk_writer:
         await DocumentTestModel.find(
@@ -127,6 +131,7 @@ async def test_upsert_find_many_not_found(documents, document_not_inserted):
 
 async def test_upsert_find_one_not_found(documents, document_not_inserted):
     await documents(5)
+    DocumentTestModel.invalidate_cache()
     document_not_inserted.test_int = -10000
     async with BulkWriter() as bulk_writer:
         await DocumentTestModel.find_one(
@@ -151,6 +156,7 @@ async def test_upsert_find_one_not_found(documents, document_not_inserted):
 
 async def test_upsert_find_many_found(documents, document_not_inserted):
     await documents(5)
+    DocumentTestModel.invalidate_cache()
     async with BulkWriter() as bulk_writer:
         await DocumentTestModel.find(DocumentTestModel.test_int == 1).upsert(
             {"$set": {DocumentTestModel.test_int: -10000}},
@@ -172,6 +178,7 @@ async def test_upsert_find_many_found(documents, document_not_inserted):
 
 async def test_upsert_find_one_found(documents, document_not_inserted):
     await documents(5)
+    DocumentTestModel.invalidate_cache()
     async with BulkWriter() as bulk_writer:
         await DocumentTestModel.find_one(
             DocumentTestModel.test_int == 1

--- a/tests/odm/documents/test_create.py
+++ b/tests/odm/documents/test_create.py
@@ -15,6 +15,7 @@ async def test_insert_one(document_not_inserted):
 
 
 async def test_insert_many(documents_not_inserted):
+    DocumentTestModel.invalidate_cache()
     await DocumentTestModel.insert_many(documents_not_inserted(10))
     documents = await DocumentTestModel.find_all().to_list()
     assert len(documents) == 10
@@ -43,6 +44,7 @@ async def test_insert_one_with_session(document_not_inserted, session):
 
 
 async def test_insert_many_with_session(documents_not_inserted, session):
+    DocumentTestModel.invalidate_cache()
     await DocumentTestModel.insert_many(
         documents_not_inserted(10), session=session
     )

--- a/tests/odm/documents/test_delete.py
+++ b/tests/odm/documents/test_delete.py
@@ -2,6 +2,7 @@ from tests.odm.models import DocumentTestModel
 
 
 async def test_delete_one(documents):
+    DocumentTestModel.invalidate_cache()
     await documents(4, "uno")
     await documents(2, "dos")
     await documents(1, "cuatro")
@@ -11,6 +12,7 @@ async def test_delete_one(documents):
 
 
 async def test_delete_one_not_found(documents):
+    DocumentTestModel.invalidate_cache()
     await documents(4, "uno")
     await documents(2, "dos")
     await documents(1, "cuatro")
@@ -20,6 +22,7 @@ async def test_delete_one_not_found(documents):
 
 
 async def test_delete_many(documents):
+    DocumentTestModel.invalidate_cache()
     await documents(4, "uno")
     await documents(2, "dos")
     await documents(1, "cuatro")
@@ -29,6 +32,7 @@ async def test_delete_many(documents):
 
 
 async def test_delete_many_not_found(documents):
+    DocumentTestModel.invalidate_cache()
     await documents(4, "uno")
     await documents(2, "dos")
     await documents(1, "cuatro")
@@ -38,6 +42,7 @@ async def test_delete_many_not_found(documents):
 
 
 async def test_delete_all(documents):
+    DocumentTestModel.invalidate_cache()
     await documents(4, "uno")
     await documents(2, "dos")
     await documents(1, "cuatro")
@@ -47,6 +52,7 @@ async def test_delete_all(documents):
 
 
 async def test_delete(document):
+    DocumentTestModel.invalidate_cache()
     doc_id = document.id
     await document.delete()
     new_document = await DocumentTestModel.get(doc_id)

--- a/tests/odm/documents/test_update.py
+++ b/tests/odm/documents/test_update.py
@@ -130,6 +130,7 @@ async def test_update_many(documents):
 
 
 async def test_update_all(documents):
+    DocumentTestModel.invalidate_cache()
     await documents(10, "foo")
     await documents(7, "bar")
     await DocumentTestModel.update_all(

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -20,6 +20,7 @@ from pymongo import IndexModel
 
 from beanie import Document, Indexed, Insert, Replace, ValidateOnSave
 from beanie.odm.actions import before_event, after_event, Delete
+from beanie.odm.cache import LRUCache
 from beanie.odm.fields import Link
 from beanie.odm.settings.timeseries import TimeSeriesConfig
 from beanie.odm.union_doc import UnionDoc
@@ -70,8 +71,7 @@ class DocumentTestModel(Document):
 
     class Settings:
         use_cache = True
-        cache_expiration_time = datetime.timedelta(seconds=10)
-        cache_capacity = 5
+        cache_system = LRUCache(capacity=5, expiration_time=datetime.timedelta(seconds=10))
         use_state_management = True
 
 

--- a/tests/odm/test_cache.py
+++ b/tests/odm/test_cache.py
@@ -1,6 +1,11 @@
 import asyncio
+import datetime
+import random
+from beanie.odm.cache import RedisCache
 
 from tests.odm.models import DocumentTestModel
+import redis
+import json
 
 
 async def test_find_one(documents):
@@ -100,3 +105,209 @@ async def test_capacity(documents):
 
     new_doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 9)
     assert docs[9] == new_doc
+
+
+def get_redis_client():
+    return redis.Redis(host="localhost", port=6379, db=random.randint(0, 15))
+
+
+async def test_find_one_with_redis_cache(documents):
+
+    seconds = 10
+
+    # Direct overwrite cache system
+    DocumentTestModel._cache = RedisCache(
+        get_redis_client(), ttl=datetime.timedelta(seconds=seconds)
+    )
+
+    await documents(5)
+    doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1)
+    await DocumentTestModel.find_one(DocumentTestModel.test_int == 1).set(
+        {DocumentTestModel.test_str: "NEW_VALUE"}
+    )
+    new_doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1)
+    assert doc == new_doc
+
+    new_doc = await DocumentTestModel.find_one(
+        DocumentTestModel.test_int == 1, ignore_cache=True
+    )
+    assert doc != new_doc
+
+    await asyncio.sleep(seconds)
+
+    new_doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1)
+    assert doc != new_doc
+
+
+async def test_find_one_with_redis_cache_and_json_serializer(documents):
+
+    seconds = 10
+
+    # Direct overwrite cache system
+    DocumentTestModel._cache = RedisCache(
+        get_redis_client(),
+        serializer=json,
+        ttl=10,
+    )
+
+    await documents(5)
+    doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1)
+    await DocumentTestModel.find_one(DocumentTestModel.test_int == 1).set(
+        {DocumentTestModel.test_str: "NEW_VALUE"}
+    )
+    new_doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1)
+    assert doc == new_doc
+
+    new_doc = await DocumentTestModel.find_one(
+        DocumentTestModel.test_int == 1, ignore_cache=True
+    )
+    assert doc != new_doc
+
+    await asyncio.sleep(seconds)
+
+    new_doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1)
+    assert doc != new_doc
+
+
+async def test_find_many_with_redis_cache(documents):
+    seconds = 10
+    # Direct overwrite cache system
+    DocumentTestModel._cache = RedisCache(
+        get_redis_client(), ttl=datetime.timedelta(seconds=seconds)
+    )
+
+    await documents(5)
+
+    docs = await DocumentTestModel.find(
+        DocumentTestModel.test_int > 1
+    ).to_list()
+
+    await DocumentTestModel.find(DocumentTestModel.test_int > 1).set(
+        {DocumentTestModel.test_str: "NEW_VALUE"}
+    )
+
+    new_docs = await DocumentTestModel.find(
+        DocumentTestModel.test_int > 1
+    ).to_list()
+    assert docs == new_docs
+
+    new_docs = await DocumentTestModel.find(
+        DocumentTestModel.test_int > 1, ignore_cache=True
+    ).to_list()
+    assert docs != new_docs
+
+    await asyncio.sleep(seconds)
+
+    new_docs = await DocumentTestModel.find(
+        DocumentTestModel.test_int > 1
+    ).to_list()
+    assert docs != new_docs
+
+
+async def test_find_many_with_redis_cache_and_json_serializer(documents):
+    seconds = 10
+    # Direct overwrite cache system
+    DocumentTestModel._cache = RedisCache(
+        get_redis_client(),
+        serializer=json,
+        ttl=datetime.timedelta(seconds=seconds),
+    )
+
+    await documents(5)
+
+    docs = await DocumentTestModel.find(
+        DocumentTestModel.test_int > 1
+    ).to_list()
+
+    await DocumentTestModel.find(DocumentTestModel.test_int > 1).set(
+        {DocumentTestModel.test_str: "NEW_VALUE"}
+    )
+
+    new_docs = await DocumentTestModel.find(
+        DocumentTestModel.test_int > 1
+    ).to_list()
+    assert docs == new_docs
+
+    new_docs = await DocumentTestModel.find(
+        DocumentTestModel.test_int > 1, ignore_cache=True
+    ).to_list()
+    assert docs != new_docs
+
+    await asyncio.sleep(10)
+
+    new_docs = await DocumentTestModel.find(
+        DocumentTestModel.test_int > 1
+    ).to_list()
+    assert docs != new_docs
+
+
+async def test_aggregation_with_redis_cache(documents):
+    seconds = 10
+    # Direct overwrite cache system
+    DocumentTestModel._cache = RedisCache(
+        get_redis_client(), ttl=datetime.timedelta(seconds=seconds)
+    )
+
+    await documents(5)
+    docs = await DocumentTestModel.aggregate(
+        [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}]
+    ).to_list()
+
+    await DocumentTestModel.find(DocumentTestModel.test_int > 1).set(
+        {DocumentTestModel.test_str: "NEW_VALUE"}
+    )
+
+    new_docs = await DocumentTestModel.aggregate(
+        [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}]
+    ).to_list()
+    assert docs == new_docs
+
+    new_docs = await DocumentTestModel.aggregate(
+        [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}],
+        ignore_cache=True,
+    ).to_list()
+    assert docs != new_docs
+
+    await asyncio.sleep(seconds)
+
+    new_docs = await DocumentTestModel.aggregate(
+        [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}]
+    ).to_list()
+    assert docs != new_docs
+
+
+async def test_aggregation_with_redis_cache_and_json_serializer(documents):
+    seconds = 10
+    # Direct overwrite cache system
+    DocumentTestModel._cache = RedisCache(
+        get_redis_client(),
+        serializer=json,
+        ttl=datetime.timedelta(seconds=seconds),
+    )
+
+    await documents(5)
+    docs = await DocumentTestModel.aggregate(
+        [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}]
+    ).to_list()
+
+    await DocumentTestModel.find(DocumentTestModel.test_int > 1).set(
+        {DocumentTestModel.test_str: "NEW_VALUE"}
+    )
+
+    new_docs = await DocumentTestModel.aggregate(
+        [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}]
+    ).to_list()
+    assert docs == new_docs
+
+    new_docs = await DocumentTestModel.aggregate(
+        [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}],
+        ignore_cache=True,
+    ).to_list()
+    assert docs != new_docs
+
+    await asyncio.sleep(seconds)
+
+    new_docs = await DocumentTestModel.aggregate(
+        [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}]
+    ).to_list()
+    assert docs != new_docs


### PR DESCRIPTION
I thought it would be a good idea to have several caching strategies, so I modified a bit the cache API to give ideas of how it could be, for example, to use Redis as a caching system.


```python
import redis
from beanie import Document
from beanie.odm.cache import RedisCache, LRUCache

redis_client = redis.Redis(host='localhost', port=6379, db=0)

class Product(Document):
    name: str
    ...

    class Settings:
        use_cache = True
        cache_system = RedisCache(redis_client)

class User(Document):
    name: str
    ...

    class Settings:
        use_cache = True
        cache_system = LRUCache(
            capacity=32, expiration_time=timedelta(seconds=10)
        )

```




