### PR TITLE
Adding Update Action

### DIFF
--- a/.github/workflows/github-actions-publish-docs.yml
+++ b/.github/workflows/github-actions-publish-docs.yml
@@ -12,9 +12,9 @@ jobs:
         with:
           python-version: 3.9
       - name: install poetry
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2
         with:
-          poetry-version: 1.1.4
+          poetry-version: 1.2
       - name: install dependencies
         run: poetry install
       - name: publish docs

--- a/.github/workflows/github-actions-publish-project.yml
+++ b/.github/workflows/github-actions-publish-project.yml
@@ -12,9 +12,9 @@ jobs:
         with:
           python-version: 3.10.5
       - name: install poetry
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2
         with:
-          poetry-version: 1.1.4
+          poetry-version: 1.2
       - name: install dependencies
         run: poetry install
       - name: publish project

--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ 3.7, 3.8, 3.9, 3.10.5 ]
-        poetry-version: [ 1.1.4 ]
+        poetry-version: [ 1.2 ]
         mongodb-version: [ 4.4, 5.0 ]
         pydantic-version: [1.9.0]
         os: [ ubuntu-18.04 ]
@@ -23,7 +23,7 @@ jobs:
           mongodb-version: ${{ matrix.mongodb-version }}
           mongodb-replica-set: test-rs
       - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2
         with:
           poetry-version: ${{ matrix.poetry-version }}
       - name: poetry install

--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -10,6 +10,7 @@ from beanie.odm.actions import (
     Before,
     After,
     Delete,
+    Update,
 )
 from beanie.odm.bulk import BulkWriter
 from beanie.odm.fields import (
@@ -46,6 +47,7 @@ __all__ = [
     "Delete",
     "Before",
     "After",
+    "Update",
     # Bulk Write
     "BulkWriter",
     # Migrations

--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -26,7 +26,7 @@ from beanie.odm.documents import Document
 from beanie.odm.views import View
 from beanie.odm.union_doc import UnionDoc
 
-__version__ = "1.11.9"
+__version__ = "1.11.10"
 __all__ = [
     # ODM
     "Document",

--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -23,6 +23,7 @@ class EventTypes(str, Enum):
     SAVE_CHANGES = "SAVE_CHANGES"
     VALIDATE_ON_SAVE = "VALIDATE_ON_SAVE"
     DELETE = "DELETE"
+    UPDATE = "UPDATE"
 
 
 Insert = EventTypes.INSERT
@@ -30,6 +31,7 @@ Replace = EventTypes.REPLACE
 SaveChanges = EventTypes.SAVE_CHANGES
 ValidateOnSave = EventTypes.VALIDATE_ON_SAVE
 Delete = EventTypes.DELETE
+Update = EventTypes.UPDATE
 
 
 class ActionDirections(str, Enum):  # TODO think about this name

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -458,6 +458,7 @@ class Document(
         await cls.find(In(cls.id, ids_list), session=session).delete()
         await cls.insert_many(documents, session=session)
 
+    @wrap_with_actions(EventTypes.UPDATE)
     @save_state_after
     async def update(
         self,
@@ -466,6 +467,7 @@ class Document(
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         skip_sync: bool = False,
+        skip_actions: Optional[List[Union[ActionDirections, str]]] = None,
         **pymongo_kwargs,
     ) -> None:
         """
@@ -478,6 +480,7 @@ class Document(
         :param **pymongo_kwargs: pymongo native parameters for update operation
         :return: None
         """
+        print("UPDATE CALL")
         use_revision_id = self.get_settings().use_revision
 
         find_query: Dict[str, Any] = {"_id": self.id}
@@ -550,6 +553,7 @@ class Document(
         :param skip_sync: bool - skip doc syncing. Available for the direct instances only
         :return: self
         """
+        print("SET CALL")
         return self.update(
             SetOperator(expression),
             session=session,

--- a/beanie/odm/interfaces/update.py
+++ b/beanie/odm/interfaces/update.py
@@ -3,6 +3,7 @@ from typing import Dict, Mapping, Union, Any, Optional
 
 from pymongo.client_session import ClientSession
 
+from beanie.odm.actions import wrap_with_actions, EventTypes
 from beanie.odm.bulk import BulkWriter
 from beanie.odm.fields import ExpressionField
 from beanie.odm.operators.update.general import (
@@ -18,6 +19,7 @@ class UpdateMethods:
     """
 
     @abstractmethod
+    @wrap_with_actions(EventTypes.UPDATE)
     def update(
         self,
         *args: Mapping[str, Any],

--- a/beanie/odm/interfaces/update.py
+++ b/beanie/odm/interfaces/update.py
@@ -3,7 +3,6 @@ from typing import Dict, Mapping, Union, Any, Optional
 
 from pymongo.client_session import ClientSession
 
-from beanie.odm.actions import wrap_with_actions, EventTypes
 from beanie.odm.bulk import BulkWriter
 from beanie.odm.fields import ExpressionField
 from beanie.odm.operators.update.general import (
@@ -19,7 +18,6 @@ class UpdateMethods:
     """
 
     @abstractmethod
-    @wrap_with_actions(EventTypes.UPDATE)
     def update(
         self,
         *args: Mapping[str, Any],

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,17 @@
 
 Beanie project
 
+## [1.11.10] - 2022-09-20
+
+### Improvement
+
+- Adding Update Action
+
+### Implementation
+
+- Author - [schwannden](https://github.com/schwannden)
+- PR <https://github.com/roman-right/beanie/pull/291/>
+
 ## [1.11.9] - 2022-08-19
 
 ### Fix

--- a/docs/tutorial/actions.md
+++ b/docs/tutorial/actions.md
@@ -7,16 +7,19 @@ Currently supported events:
 - Replace
 - SaveChanges
 - ValidateOnSave
+- Update
 
 Currently supported directions:
 - Before
 - After
 
 Current operations creating events:
-- `insert()` and `save()` for Insert
-- `replace()` and `save()` for Replace
+- `insert()` for Insert
+- `replace()` Replace
+- `save()` triggers Insert if it is creating a new document, triggers Replace it replaces existing document.
 - `save_changes()` for SaveChanges
 - `insert()`, `replace()`, `save_changes()`, and `save()` for ValidateOnSave
+- `set()`, `update()` for Update
 
 To register an action you can use `@before_event` and `@after_event` decorators respectively.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beanie"
-version = "1.11.9"
+version = "1.11.10"
 description = "Asynchronous Python ODM for MongoDB"
 authors = ["Roman <roman-right@protonmail.com>"]
 license = "Apache-2.0"

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -244,11 +244,11 @@ class DocumentWithActions(Document):
         self.Inner.inner_num_2 = 2
 
     @before_event(Update)
-    def inner_num_to_one(self):
+    def inner_num_to_one_2(self):
         self.Inner.inner_num_1 += 1
 
     @after_event(Update)
-    def inner_num_to_two(self):
+    def inner_num_to_two_2(self):
         self.Inner.inner_num_2 -= 1
 
 

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -18,7 +18,7 @@ from pydantic.color import Color
 from pydantic import BaseModel, Field
 from pymongo import IndexModel
 
-from beanie import Document, Indexed, Insert, Replace, ValidateOnSave
+from beanie import Document, Indexed, Insert, Replace, ValidateOnSave, Update
 from beanie.odm.actions import before_event, after_event, Delete
 from beanie.odm.fields import Link
 from beanie.odm.settings.timeseries import TimeSeriesConfig
@@ -242,6 +242,14 @@ class DocumentWithActions(Document):
     @after_event(Delete)
     def inner_num_to_two(self):
         self.Inner.inner_num_2 = 2
+
+    @before_event(Update)
+    def inner_num_to_one(self):
+        self.Inner.inner_num_1 += 1
+
+    @after_event(Update)
+    def inner_num_to_two(self):
+        self.Inner.inner_num_2 -= 1
 
 
 class InheritedDocumentWithActions(DocumentWithActions):

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -245,11 +245,12 @@ class DocumentWithActions(Document):
 
     @before_event(Update)
     def inner_num_to_one_2(self):
-        self.Inner.inner_num_1 += 1
+        print("HERE")
+        self.num_1 += 1
 
     @after_event(Update)
     def inner_num_to_two_2(self):
-        self.Inner.inner_num_2 -= 1
+        self.num_2 -= 1
 
 
 class InheritedDocumentWithActions(DocumentWithActions):

--- a/tests/odm/test_actions.py
+++ b/tests/odm/test_actions.py
@@ -79,13 +79,17 @@ class TestActions:
     async def test_actions_update(self, doc_class):
         test_name = f"test_actions_update_{doc_class}"
         sample = doc_class(name=test_name)
+        await sample.save()
 
         await sample.update({"$set": {"name": "new_name"}})
         assert sample.name == "new_name"
-        assert sample.Inner.inner_num_1 == 1
-        assert sample.Inner.inner_num_2 == 9
+        assert sample.num_1 == 2
+        assert sample.num_2 == 9
 
-        await sample.set({"name": "awesome_name"})
+        await sample.set({"name": "awesome_name"}, skip_sync=True)
+
+        assert sample.num_1 == 3
+        assert sample.num_2 == 8
+
+        await sample._sync()
         assert sample.name == "awesome_name"
-        assert sample.Inner.inner_num_1 == 2
-        assert sample.Inner.inner_num_2 == 8

--- a/tests/odm/test_actions.py
+++ b/tests/odm/test_actions.py
@@ -66,9 +66,26 @@ class TestActions:
         "doc_class", [DocumentWithActions, InheritedDocumentWithActions]
     )
     async def test_actions_delete(self, doc_class):
-        test_name = f"test_actions_insert_{doc_class}"
+        test_name = f"test_actions_delete_{doc_class}"
         sample = doc_class(name=test_name)
 
         await sample.delete()
         assert sample.Inner.inner_num_1 == 1
         assert sample.Inner.inner_num_2 == 2
+
+    @pytest.mark.parametrize(
+        "doc_class", [DocumentWithActions, InheritedDocumentWithActions]
+    )
+    async def test_actions_update(self, doc_class):
+        test_name = f"test_actions_update_{doc_class}"
+        sample = doc_class(name=test_name)
+
+        await sample.update({"$set": {"name": "new_name"}})
+        assert sample.name == "new_name"
+        assert sample.Inner.inner_num_1 == 1
+        assert sample.Inner.inner_num_2 == 9
+
+        await sample.set({"name": "awesome_name"})
+        assert sample.name == "awesome_name"
+        assert sample.Inner.inner_num_1 == 2
+        assert sample.Inner.inner_num_2 == 8

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.11.9"
+    assert __version__ == "1.11.10"


### PR DESCRIPTION
When using `Document.update` or `Document.set` (which triggers Document.update), it will trigger `Update` action and its registered hook. This has the benefit of allowing people who use update or set to also use actions to implement hooks like updating `updated_at` timestamp.