### PR TITLE
fix: add count support for aggregations

### DIFF
--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from random import randint
-from typing import List
+from typing import List, Optional
 
 import pytest
 
@@ -189,7 +189,10 @@ def document_not_inserted():
 @pytest.fixture
 def documents_not_inserted():
     def generate_documents(
-        number: int, test_str: str = None, random: bool = False
+        number: int,
+        test_str: str = None,
+        test_link: Optional[DocumentTestModel] = None,
+        random: bool = False,
     ) -> List[DocumentTestModel]:
         return [
             DocumentTestModel(
@@ -200,6 +203,7 @@ def documents_not_inserted():
                 ],
                 test_doc=SubDocument(test_str="foobar"),
                 test_str="kipasa" if test_str is None else test_str,
+                test_link=test_link,
             )
             for i in range(number)
         ]
@@ -215,10 +219,13 @@ async def document(document_not_inserted, loop) -> DocumentTestModel:
 @pytest.fixture
 def documents(documents_not_inserted):
     async def generate_documents(
-        number: int, test_str: str = None, random: bool = False
+        number: int,
+        test_str: Optional[str] = None,
+        test_link: Optional[DocumentTestModel] = None,
+        random: bool = False,
     ):
         result = await DocumentTestModel.insert_many(
-            documents_not_inserted(number, test_str, random)
+            documents_not_inserted(number, test_str, test_link, random)
         )
         return result.inserted_ids
 

--- a/tests/odm/documents/test_count.py
+++ b/tests/odm/documents/test_count.py
@@ -2,14 +2,27 @@ from tests.odm.models import DocumentTestModel
 
 
 async def test_count(documents):
-    await documents(4, "uno", True)
+    await documents(4, "uno", random=True)
     c = await DocumentTestModel.count()
     assert c == 4
 
 
 async def test_count_with_filter_query(documents):
-    await documents(4, "uno", True)
-    await documents(2, "dos", True)
-    await documents(1, "cuatro", True)
+    await documents(4, "uno", random=True)
+    await documents(2, "dos", random=True)
+    await documents(1, "cuatro", random=True)
     c = await DocumentTestModel.find_many({"test_str": "dos"}).count()
     assert c == 2
+
+
+async def test_count_with_filter_query_and_linked_document(
+    documents, document
+):
+    await documents(4, "uno", document, random=True)
+    await documents(1, "dos", random=True)
+    await documents(1, "cuatro", random=True)
+
+    c = await DocumentTestModel.find_many(
+        DocumentTestModel.test_str == document.test_str
+    ).count()
+    assert c == 1

--- a/tests/odm/documents/test_exists.py
+++ b/tests/odm/documents/test_exists.py
@@ -2,9 +2,9 @@ from tests.odm.models import DocumentTestModel
 
 
 async def test_count_with_filter_query(documents):
-    await documents(4, "uno", True)
-    await documents(2, "dos", True)
-    await documents(1, "cuatro", True)
+    await documents(4, "uno", random=True)
+    await documents(2, "dos", random=True)
+    await documents(1, "cuatro", random=True)
     e = await DocumentTestModel.find_many({"test_str": "dos"}).exists()
     assert e is True
 

--- a/tests/odm/documents/test_find.py
+++ b/tests/odm/documents/test_find.py
@@ -61,9 +61,9 @@ async def test_find_all_skip(documents):
 
 
 async def test_find_all_sort(documents):
-    await documents(4, "uno", True)
-    await documents(2, "dos", True)
-    await documents(1, "cuatro", True)
+    await documents(4, "uno", random=True)
+    await documents(2, "dos", random=True)
+    await documents(1, "cuatro", random=True)
     result = await DocumentTestModel.find_all(
         sort=[
             ("test_str", pymongo.ASCENDING),
@@ -120,9 +120,9 @@ async def test_find_many_skip(documents):
 
 
 async def test_find_many_sort(documents):
-    await documents(4, "uno", True)
-    await documents(2, "dos", True)
-    await documents(1, "cuatro", True)
+    await documents(4, "uno", random=True)
+    await documents(2, "dos", random=True)
+    await documents(1, "cuatro", random=True)
     result = await DocumentTestModel.find_many(
         {"test_str": "uno"}, sort="test_int"
     ).to_list()

--- a/tests/odm/documents/test_init.py
+++ b/tests/odm/documents/test_init.py
@@ -227,9 +227,10 @@ async def test_projection():
     projection = get_projection(DocumentTestModel)
     assert projection == {
         "_id": 1,
+        "revision_id": 1,
         "test_int": 1,
         "test_list": 1,
-        "test_str": 1,
         "test_doc": 1,
-        "revision_id": 1,
+        "test_str": 1,
+        "test_link": 1,
     }

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -67,6 +67,7 @@ class DocumentTestModel(Document):
     test_list: List[SubDocument] = Field(hidden=True)
     test_doc: SubDocument
     test_str: str
+    test_link: Optional[Link[Document]] = None
 
     class Settings:
         use_cache = True


### PR DESCRIPTION
Calling `.count()` on a `FindMany` object that was constructed with the `fetch_links` parameter does not work properly, as the function does not currently make use of motor's `.aggregate(...)`. This PR aims to fix that by appending the aggregation pipeline and drawing the count from there.

Hopefully this is helpful - love the project!