### PR TITLE
doc(events): fix formatting and add documentation for Delete event

### DIFF
--- a/docs/tutorial/actions.md
+++ b/docs/tutorial/actions.md
@@ -6,10 +6,10 @@ Currently supported events:
 
 - Insert
 - Replace
+- Update
 - SaveChanges
 - Delete
 - ValidateOnSave
-- Update
 
 Currently supported directions:
 
@@ -24,6 +24,7 @@ Current operations creating events:
 - `save_changes()` for SaveChanges
 - `insert()`, `replace()`, `save_changes()`, and `save()` for ValidateOnSave
 - `set()`, `update()` for Update
+- `delete()` for Delete
 
 To register an action, you can use `@before_event` and `@after_event` decorators respectively:
 

--- a/docs/tutorial/actions.md
+++ b/docs/tutorial/actions.md
@@ -3,20 +3,25 @@
 You can register methods as pre- or post- actions for document events.
 
 Currently supported events:
+
 - Insert
 - Replace
 - SaveChanges
+- Delete
 - ValidateOnSave
 
 Currently supported directions:
+
 - Before
 - After
 
 Current operations creating events:
+
 - `insert()` and `save()` for Insert
 - `replace()` and `save()` for Replace
 - `save_changes()` for SaveChanges
 - `insert()`, `replace()`, `save_changes()`, and `save()` for ValidateOnSave
+- `delete()` for Delete
 
 To register an action you can use `@before_event` and `@after_event` decorators respectively.
 


### PR DESCRIPTION
Hi,

I saw that the formatting was wrong in the doc, so I fixed it, and added the documentation for the delete event added following [this](https://github.com/roman-right/beanie/issues/225) issue.

Best,