### PR TITLE
Skip sync parameter for instance updates

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -25,7 +25,7 @@ from beanie.odm.documents import Document
 from beanie.odm.views import View
 from beanie.odm.union_doc import UnionDoc
 
-__version__ = "1.11.7"
+__version__ = "1.11.8"
 __all__ = [
     # ODM
     "Document",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,13 @@
 
 Beanie project
 
-## [1.11.7] - 2022-02-08
+## [1.11.8] - 2022-08-17
+
+### Improvement
+
+- Skip sync parameter for instance updates
+
+## [1.11.7] - 2022-08-02
 
 ### Improvement
 
@@ -13,25 +19,25 @@ Beanie project
 - Author - [Teslim Olunlade](https://github.com/ogtega)
 - PR <https://github.com/roman-right/beanie/pull/321>
 
-## [1.11.6] - 2022-24-06
+## [1.11.6] - 2022-06-24
 
 ### Fix
 
 - Roll back projections fix, as it was valid
 
-## [1.11.5] - 2022-24-06
+## [1.11.5] - 2022-06-24
 
 ### Fix
 
 - Projection fix for aggregations
 
-## [1.11.4] - 2022-13-06
+## [1.11.4] - 2022-06-13
 
 ### Improvement
 
 - Link as FastAPI output
 
-## [1.11.3] - 2022-10-06
+## [1.11.3] - 2022-06-10
 
 ### Improvement
 
@@ -917,3 +923,7 @@ how specific type should be presented in the database
 [1.11.5]: https://pypi.org/project/beanie/1.11.5
 
 [1.11.6]: https://pypi.org/project/beanie/1.11.6
+
+[1.11.7]: https://pypi.org/project/beanie/1.11.7
+
+[1.11.8]: https://pypi.org/project/beanie/1.11.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beanie"
-version = "1.11.7"
+version = "1.11.8"
 description = "Asynchronous Python ODM for MongoDB"
 authors = ["Roman <roman-right@protonmail.com>"]
 license = "Apache-2.0"

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Set, Tuple, Union
 from uuid import UUID, uuid4
 
 import pymongo
-from pydantic import SecretBytes, SecretStr, Extra
+from pydantic import SecretBytes, SecretStr, Extra, PrivateAttr
 from pydantic.color import Color
 from pydantic import BaseModel, Field
 from pymongo import IndexModel
@@ -249,9 +249,16 @@ class InheritedDocumentWithActions(DocumentWithActions):
 
 
 class InternalDoc(BaseModel):
+    _private_field: str = PrivateAttr(default="TEST_PRIVATE")
     num: int = 100
     string: str = "test"
     lst: List[int] = [1, 2, 3, 4, 5]
+
+    def change_private(self):
+        self._private_field = "PRIVATE_CHANGED"
+
+    def get_private(self):
+        return self._private_field
 
 
 class DocumentWithTurnedOnStateManagement(Document):

--- a/tests/odm/test_state_management.py
+++ b/tests/odm/test_state_management.py
@@ -126,8 +126,12 @@ def test_get_changes_replace_whole(doc_replace):
 
 async def test_save_changes(saved_doc_default):
     saved_doc_default.internal.num = 10000
+    saved_doc_default.internal.change_private()
+    assert saved_doc_default.internal.get_private() == "PRIVATE_CHANGED"
+
     await saved_doc_default.save_changes()
     assert saved_doc_default.get_saved_state()["internal"]["num"] == 10000
+    assert saved_doc_default.internal.get_private() == "PRIVATE_CHANGED"
 
     new_doc = await DocumentWithTurnedOnStateManagement.get(
         saved_doc_default.id

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.11.7"
+    assert __version__ == "1.11.8"


### PR DESCRIPTION
Sync with DB is not needed for some updates. Now this is optional