### PR TITLE
fix: Tutorial section - Documentation links and wording fixes

### DIFF
--- a/docs/tutorial/actions.md
+++ b/docs/tutorial/actions.md
@@ -60,7 +60,7 @@ class Sample(Document):
         self.name = self.name.capitalize()
 ```
 
-This will capitalize the `name` field value before each document insert and replace.
+This will capitalize the `name` field value before each document's Insert and Replace.
 
 And sync and async methods could work as actions.
 
@@ -77,7 +77,7 @@ class Sample(Document):
         await client.send(self.id)
 ```
 
-Actions can be selectively skipped by passing the parameter `skip_actions` when calling
+Actions can be selectively skipped by passing the `skip_actions` argument when calling
 the operations that trigger events. `skip_actions` accepts a list of directions and action names.
 
 ```python

--- a/docs/tutorial/aggregate.md
+++ b/docs/tutorial/aggregate.md
@@ -12,10 +12,11 @@ avg_price = await Product.find(
 avg_price = await Product.avg(Product.price)
 ```
 
-A full list of avalible methods can be found [here](/beanie/api-documentation/interfaces/#aggregateinterfaceaggregate).
+A full list of available methods can be found [here](/api-documentation/interfaces/#aggregatemethods).
 
-You can also use the native PyMongo syntax by calling the `aggregate` method. However, as Beanie will not know what output 
-to expect, you will have to supply a projection model yourself. If you do not supply a projection model, then a dictionary will be returned.
+You can also use the native PyMongo syntax by calling the `aggregate` method. 
+However, as Beanie will not know what output to expect, you will have to supply a projection model yourself. 
+If you do not supply a projection model, then a dictionary will be returned.
 
 ```python
 class OutputItem(BaseModel):

--- a/docs/tutorial/cache.md
+++ b/docs/tutorial/cache.md
@@ -1,8 +1,7 @@
 # Cache
+All query results could be locally cached.
 
-All the query results could be locally cached.
-
-This feature must be turned on in the `Settings` inner class explicitly.
+This feature must be explicitly turned on in the `Settings` inner class.
 
 ```python
 class Sample(Document):
@@ -13,7 +12,8 @@ class Sample(Document):
         use_cache = True
 ```
 
-Beanie uses LRU cache with expiration time. You can set `capacity` (the maximum number of the cached queries) and expiration time in the `Settings` inner class.
+Beanie uses LRU cache with expiration time. 
+You can set `capacity` (the maximum number of the cached queries) and expiration time in the `Settings` inner class.
 
 ```python
 class Sample(Document):

--- a/docs/tutorial/collection_setup.md
+++ b/docs/tutorial/collection_setup.md
@@ -1,7 +1,8 @@
 # Collection setup (name, indexes, timeseries)
 
-Although the basic pydantic syntax allows you to set all aspects of individual fields, there is also some need to configure 
-collections as a whole. In particular, you might want to:
+Although basic pydantic syntax allows you to set all aspects of individual fields, 
+there is also some need to configure collections as a whole. 
+In particular, you might want to:
 
 - Set the MongoDB collection name
 - Configure indexes
@@ -10,7 +11,7 @@ This is done by defining a `Settings` class within your `Document` class.
 
 ## Declaring the collection name
 
-To set MongoDB collection name you can use the `name` field of the `Settings` inner class.
+To set MongoDB collection name, you can use the `name` field of the `Settings` inner class.
 
 ```python
 from beanie import Document
@@ -28,7 +29,8 @@ class Sample(Document):
 
 ### Indexed function
 
-To set up an index over a single field the `Indexed` function can be used to wrap the type and does not require a `Settings` class:
+To set up an index over a single field, the `Indexed` function can be used to wrap the type 
+and does not require a `Settings` class:
 
 ```python
 from beanie import Document, Indexed
@@ -39,7 +41,7 @@ class Sample(Document):
     description: str
 ```
 
-The `Indexed` function takes an optional argument `index_type`, which may be set to a pymongo index type:
+The `Indexed` function takes an optional `index_type` argument, which may be set to a pymongo index type:
 
 ```python
 import pymongo
@@ -53,7 +55,7 @@ class Sample(Document):
 
 The `Indexed` function also supports PyMongo's `IndexModel` kwargs arguments (see the [PyMongo Documentation](https://pymongo.readthedocs.io/en/stable/api/pymongo/operations.html#pymongo.operations.IndexModel) for details). 
  
-For example to create a `unique` index:
+For example, to create a `unique` index:
 
 ```python
 from beanie import Document, Indexed
@@ -63,12 +65,13 @@ class Sample(Document):
     name: Indexed(str, unique=True)
 ```
 
-### Multi-field indices
+### Multi-field indexes
 
-The `indexes` field of the inner `Settings` class is responsible for more complex indexes. It is a list where items could be:
+The `indexes` field of the inner `Settings` class is responsible for more complex indexes. 
+It is a list where items can be:
 
-- single key. Name of the document's field (this is equivalent to using the Indexed function described above without any additional arguments)
-- list of (key, direction) pairs. Key - string, name of the document's field. Direction - pymongo direction (
+- Single key. Name of the document's field (this is equivalent to using the Indexed function described above without any additional arguments)
+- List of (key, direction) pairs. Key - string, name of the document's field. Direction - pymongo direction (
   example: `pymongo.ASCENDING`)
 - `pymongo.IndexModel` instance - the most flexible
   option. [PyMongo Documentation](https://pymongo.readthedocs.io/en/stable/api/pymongo/operations.html#pymongo.operations.IndexModel)
@@ -100,7 +103,7 @@ class Sample(Document):
 
 ## Time series
 
-You can set up a timeseries collection using inner class `Settings`.
+You can set up a timeseries collection using the inner `Settings` class.
 
 **Be aware, timeseries collections a supported by MongoDB 5.0 and higher only.**
 
@@ -124,6 +127,6 @@ class Sample(Document):
         )
 ```
 
-TimeSeriesConfig fields are reflecting the respective parameters of the timeseries creation function of MongoDB.
+TimeSeriesConfig fields reflect the respective parameters of the MongoDB timeseries creation function.
 
 MongoDB documentation: https://docs.mongodb.com/manual/core/timeseries-collections/

--- a/docs/tutorial/defining-a-document.md
+++ b/docs/tutorial/defining-a-document.md
@@ -37,14 +37,17 @@ class Product(Document):  # This is the model
 
 ## Fields
 
-As it is mentioned before, the `Document` class is inherited from the Pydantic `BaseModel` class. It uses all the same patterns of `BaseModel`. But also it has special types of fields:
+As it was mentioned before, the `Document` class is inherited from the Pydantic `BaseModel` class. 
+It uses all the same patterns of `BaseModel`. But also it has special types of fields:
 
 - id
 - Indexed
 
 ### id
 
-`id` field of the `Document` class reflects the unique `_id` field of the MongoDB document. Each object of the `Document` type has this field. The default type of this is [PydanticObjectId](https://roman-right.github.io/beanie/api/fields/#pydanticobjectid).
+`id` field of the `Document` class reflects the unique `_id` field of the MongoDB document. 
+Each object of the `Document` type has this field. 
+The default type of this is [PydanticObjectId](/api-documentation/fields/#pydanticobjectid).
 
 ```python
 class Sample(Document):
@@ -94,7 +97,7 @@ class Sample(Document):
 
 The `Indexed` function also supports pymongo `IndexModel` kwargs arguments ([PyMongo Documentation](https://pymongo.readthedocs.io/en/stable/api/pymongo/operations.html#pymongo.operations.IndexModel)). 
  
-For example to create a `unique` index:
+For example, to create a `unique` index:
 
 ```python
 class Sample(Document):
@@ -110,7 +113,7 @@ The inner class `Settings` is used to configure:
 
 ### Collection name
 
-To set MongoDB collection name you can use the `name` field of the `Settings` inner class.
+To set MongoDB collection name, you can use the `name` field of the `Settings` inner class.
 
 ```python
 class Sample(Document):
@@ -123,7 +126,8 @@ class Sample(Document):
 
 ### Indexes
 
-The `indexes` field of the inner `Settings` class is responsible for the indexes setup. It is a list where items could be:
+The `indexes` field of the inner `Settings` class is responsible for the indexes' setup. 
+It is a list where items can be:
 
 - Single key. Name of the document's field (this is equivalent to using the Indexed function described above)
 - List of (key, direction) pairs. Key - string, name of the document's field. Direction - pymongo direction (
@@ -163,9 +167,10 @@ The inner class `Settings` is used to configure:
 
 ### Encoders
 
-The `bson_encoders` field of the inner `Settings` class defines how are the Python types going to be represented when saved in the database. The default conversions can be overridden with this.
+The `bson_encoders` field of the inner `Settings` class defines how the Python types are going to be represented 
+when saved in the database. The default conversions can be overridden with this.
 
-The `ip` field in the following example would be converted to String by default:
+The `ip` field in the following example is converted to String by default:
 
 ```python
 from ipaddress import IPv4Address
@@ -176,7 +181,8 @@ class Sample(Document):
 ```
 > **Note:** Default conversions are defined in `beanie.odm.utils.bson.ENCODERS_BY_TYPE`.
 
-However, if you wanted the `ip` field to be represented as Integer in the database you need to override default encoders like this:
+However, if you want the `ip` field to be represented as Integer in the database, 
+you need to override the default encoders like this:
 
 ```python
 from ipaddress import IPv4Address

--- a/docs/tutorial/delete.md
+++ b/docs/tutorial/delete.md
@@ -1,6 +1,6 @@
 # Delete documents
 
-Beanie supports, and single, and batch deletions:
+Beanie supports single and batch deletions:
 
 ## Single
 

--- a/docs/tutorial/find.md
+++ b/docs/tutorial/find.md
@@ -1,14 +1,17 @@
-To populate the database, please run the examples from the [previous section of the tutorial](inserting-into-the-database.md) as we will be using the same setup here.
+To populate the database, please run the examples from the [previous section of the tutorial](inserting-into-the-database.md) 
+as we will be using the same setup here.
 
 ## Finding documents
 
-The basic syntax for finding multiple documents in the database is to call the classmethod `find()` or it's synonym `find_many()` with some search criteria (see next section): 
+The basic syntax for finding multiple documents in the database is to call the class method `find()` 
+or it's synonym `find_many()` with some search criteria (see next section): 
 
 ```python
 findresult = Product.find(search_criteria)
 ```
 
-This returns a `FindMany` object which can be used to access the results in different ways. To loop through the results, use a `async for` loop:
+This returns a `FindMany` object, which can be used to access the results in different ways. 
+To loop through the results, use a `async for` loop:
 
 ```python
 async for result in Product.find(search_criteria):
@@ -21,7 +24,8 @@ If you prefer a list of the results, then you can call `to_list()` method:
 result = await Product.find(search_criteria).to_list()
 ```
 
-To get the first document you can use `.first_or_none()` method. It returns the first found document or `None`, if no documents were found.
+To get the first document, you can use `.first_or_none()` method. 
+It returns the first found document or `None`, if no documents were found.
 
 ```python
 result = await Product.find(search_criteria).first_or_none()
@@ -37,8 +41,9 @@ fields):
 products = await Product.find(Product.price < 10).to_list()
 ```
 
-This is supported for the operators: `==`, `>`, `>=`, `<`, `<=`, `!=`.
-Other MongoDB query operators can be used with the included wrappers. For example the `$in` operator can be used as follows:
+This is supported for the following operators: `==`, `>`, `>=`, `<`, `<=`, `!=`.
+Other MongoDB query operators can be used with the included wrappers. 
+For example, the `$in` operator can be used as follows:
 
 ```python
 from beanie.operators import In
@@ -48,7 +53,7 @@ products = await Product.find(
 ).to_list()
 ```
 
-The whole list of the find query operators can be found [here](/beanie/api-documentation/operators/find).
+The whole list of the find query operators can be found [here](/api-documentation/operators/find).
 
 For more complex cases native PyMongo syntax is also supported:
 
@@ -58,13 +63,15 @@ products = await Product.find({"price": 1000}).to_list()
 
 ## Finding single documents
 
-Sometimes you will only need to find a single document. If you are searching by `id` then you can use the [get](/beanie/api-documentation/document/#documentget) method:
+Sometimes you will only need to find a single document. 
+If you are searching by `id`, then you can use the [get](/api-documentation/document/#documentget) method:
 
 ```python
 bar = await Product.get("608da169eb9e17281f0ab2ff")
 ```
 
-To find a single document via a searching criteria, you can use the [find_one](/beanie/api-documentation/document/#documentfind_one) method:
+To find a single document via a single search criterion,
+you can use the [find_one](/api-documentation/interfaces/#findinterfacefind_one) method:
 
 ```python
 bar = await Product.find_one(Product.name == "Peanut Bar")
@@ -74,7 +81,8 @@ bar = await Product.find_one(Product.name == "Peanut Bar")
 
 ### Multiple search criteria
 
-If you have multiple search criteria to search for you can list them as separate arguments to any of the `find` functions:
+If you have multiple criteria to search against, 
+you can pass them as separate arguments to any of the `find` functions:
 
 ```python
 chocolates = await Product.find(
@@ -96,7 +104,8 @@ chocolates = await Product
 
 Sorting can be done with the [sort](/api-documentation/query#sort) method.
 
-You can pass it one or multiple fields to sort by. You may optionally specify a `+` or `-` (denoting ascending and descending respectively).
+You can pass it one or multiple fields to sort by. You may optionally specify a `+` or `-` 
+(denoting ascending and descending respectively).
 
 ```python
 chocolates = await Product.find(
@@ -120,7 +129,8 @@ chocolates = await Product.find(
 
 ### Skip and limit
 
-To skip a certain number of documents, or limit the total number of elements returned, the `skip`and `limit` methods can be used:
+To skip a certain number of documents, or limit the total number of elements returned, 
+the `skip` and `limit` methods can be used:
 ```python
 chocolates = await Product.find(
     Product.category.name == "Chocolate").skip(2).to_list()
@@ -131,7 +141,7 @@ chocolates = await Product.find(
 
 ### Projections
 
-When only part of a document is required, projections can save a lot of database bandwidth and processing.
+When only a part of a document is required, projections can save a lot of database bandwidth and processing.
 For simple projections we can just define a pydantic model with the required fields and pass it to `project()` method:
 
 ```python
@@ -161,4 +171,4 @@ chocolates = await Product.find(
 
 ### Finding all documents
 
-If you every want to find all documents you can use the `find_all()` classmethod. This is equivalent to `find({})`.
+If you ever want to find all documents, you can use the `find_all()` class method. This is equivalent to `find({})`.

--- a/docs/tutorial/init.md
+++ b/docs/tutorial/init.md
@@ -1,4 +1,6 @@
-Beanie uses Motor as an async database engine. To initialize previously created documents, you should provide a Motor database instance and list of your document models to the `init_beanie(...)` function, as it is shown in the example:
+Beanie uses Motor as an async database engine. 
+To initialize previously created documents, you should provide a Motor database instance 
+and a list of your document models to the `init_beanie(...)` function, as it is shown in the example:
 
 ```python
 from beanie import init_beanie, Document
@@ -20,7 +22,8 @@ async def init():
 This creates the collection (if necessary) and sets up any indexes that are defined.
 
 
-`init_beanie` supports not only list of classes for the document_models parameter, but also strings with the dot separated paths:
+`init_beanie` supports not only a list of classes as the document_models argument, 
+but also strings with dot-separated paths:
 
 ```python
 await init_beanie(
@@ -33,6 +36,7 @@ await init_beanie(
 
 ### Warning
 
-`init_beanie` supports a parameter named `allow_index_dropping` that will drop indexes from your collection(s). 
-`allow_index_dropping` is by default set to `False`. If you set this to `True`, your indexes will be dropped, 
-ensure that you are not managing your indexes in another manner, if you are, these will be deleted when setting `allow_index_dropping=True`.
+`init_beanie` supports the parameter named `allow_index_dropping` that will drop indexes from your collections. 
+`allow_index_dropping` is by default set to `False`. If you set this to `True`, 
+ensure that you are not managing your indexes in another manner. 
+If you are, these will be deleted when setting `allow_index_dropping=True`.

--- a/docs/tutorial/insert.md
+++ b/docs/tutorial/insert.md
@@ -35,15 +35,16 @@ This however does not save the documents to the database yet.
 
 ## Insert a single document
 
-To insert a document into the database, you can call either `insert()` or `create()` on it, they are synonyms:
+To insert a document into the database, you can call either `insert()` or `create()` on it (they are synonyms):
 
 ```python
 await tonybar.insert()
 await marsbar.create()  # does exactly the same as insert()
 ```
-You can also call `save()`, which behaves the same for new documents, but will also update existing documents. See the [section on updating](updating-&-deleting.md) of this tutorial for more details.
+You can also call `save()`, which behaves in the same manner for new documents, but will also update existing documents. 
+See the [section on updating](updating-&-deleting.md) of this tutorial for more details.
 
-If you prefer you can also call the `insert_one` classmethod: 
+If you prefer, you can also call the `insert_one` class method: 
 
 ```python
 await Product.insert_one(tonybar)
@@ -51,7 +52,8 @@ await Product.insert_one(tonybar)
 
 ## Inserting many documents
 
-To reduce the number of database queries, similarly typed documents should be inserted together by calling the classmethod `insert_many`:
+To reduce the number of database queries, 
+similarly typed documents should be inserted together by calling the class method `insert_many`:
 
 ```python
 await Product.insert_many([tonybar,marsbar])

--- a/docs/tutorial/migrations.md
+++ b/docs/tutorial/migrations.md
@@ -1,46 +1,47 @@
 ## Attention!
 
-Migrations use transactions inside. It works only with **MongoDB replica sets**
+Migrations use transactions inside. They work only with **MongoDB replica sets**
 
 ## Create
 
-To create a new migration run:
+To create a new migration, run:
 
 ```shell
 beanie new-migration -n migration_name -p relative/path/to/migrations/directory/
 ```
 
-It will create a file with the name `*_migration_name.py` in the directory `relative/path/to/migrations/directory/`
+It will create a file named `*_migration_name.py` in the directory `relative/path/to/migrations/directory/`
 
-Migration file contains two classes: `Forward` and `Backward`. Each one contains instructions to roll migration respectively forward and backward.
+Migration file contains two classes: `Forward` and `Backward`. 
+Each one contains instructions to roll migration respectively forward and backward.
 
 ## Run
 
-To roll one migration forward run:
+To roll one forward migration, run:
 
 ```shell
 beanie migrate -uri 'mongodb+srv://user:pass@host/db' -p relative/path/to/migrations/directory/ --distance 1
 ```
 
-To roll all the migrations forward run:
+To roll all forward migrations, run:
 
 ```shell
 beanie migrate -uri 'mongodb+srv://user:pass@host/db' -p relative/path/to/migrations/directory/
 ```
 
-To roll one migration backward run:
+To roll one backward migration, run:
 
 ```shell
 beanie migrate -uri 'mongodb+srv://user:pass@host/db' -p relative/path/to/migrations/directory/ --distance 1 --backward
 ```
 
-To roll all the migrations backward run:
+To roll all backward migrations, run:
 
 ```shell
 beanie migrate -uri 'mongodb+srv://user:pass@host/db' -p relative/path/to/migrations/directory/ --backward
 ```
 
-To show help message with all the parameters and descriptions run
+To show the help message with all the parameters and descriptions, run:
 
 ```shell
 beanie migrate --help
@@ -50,12 +51,13 @@ beanie migrate --help
 
 Migration class contains instructions - decorated async functions. There are two types of instructions:
 
-- Iterative migration - instruction, which iterates over all the documents of the input_document collection and updates it. Most comfortable to use. Can be used in 99% cases.
-- Free fall migrations - instruction, where user can write any logic. Most flexible, but verbose.
+- Iterative migration - instruction that iterates over all the documents of the input_document collection and updates it. Most convenient to use, should be used in 99% cases.
+- Free fall migrations - instruction where user can write any logic. Most flexible, but verbose.
 
 ### Iterative migrations
 
-To mark a function as iterative migration must be used decorator `@iterative_migration()`. The function itself as parameters must have `input_document` with type and `output_document` with type. Like here:
+To mark a function as iterative migration, `@iterative_migration()` decorator must be used. 
+The function itself must accept typed `input_document` and `output_document` arguments. Like here:
 
 ```python
 @iterative_migration()
@@ -93,7 +95,7 @@ class Note(Document):
 
 ```
 
-To migrate from `OldNote` to `Note` filed `name` has to be renamed to `title`.
+To migrate from `OldNote` to `Note`, file `name` has to be renamed to `title`.
 
 Forward migration:
 
@@ -167,14 +169,18 @@ class Backward:
     ):
         output_document.tag.name = input_document.tag.title
 ```
-
-All the migrations examples can be found by [link](https://github.com/roman-right/beanie/tree/main/tests/migrations/migrations_for_test)
+All the examples of migrations can be found by [link](https://github.com/roman-right/beanie/tree/main/tests/migrations/migrations_for_test)
 
 ### Free fall migrations
 
-It is a much more flexible migration type, which allows to implementation of any migration logic. But at the same time, it is more verbose.
+It is a much more flexible migration type, which allows the implementation of any migration logic. 
+But at the same time, it is more verbose.
 
-To mark function as a free fall migration, must be used decorator `@free_fall_migration()` with the list of Document classes, which will be used in this migration. Function itself receives `session` as a parameter. It is used to be able to roll back the migration, if something went wrong. To be able to roll back, please provide session into the Documents methods. Like here:
+To mark function as a free fall migration, 
+`@free_fall_migration()` decorator with the list of Document classes must be used. 
+Function itself accepts `session` as an argument. 
+It is used in order to roll back the migration in case something has gone wrong. 
+To be able to roll back, please pass session to the Documents methods. Like here:
 
 ```python
 @free_fall_migration(document_models=[OldNote, Note])
@@ -235,5 +241,4 @@ class Backward:
             await new_note.replace(session=session)
 
 ```
-
-All the migrations examples can be found by [link](https://github.com/roman-right/beanie/tree/main/tests/migrations/migrations_for_test)
+All the examples of migrations can be found by [link](https://github.com/roman-right/beanie/tree/main/tests/migrations/migrations_for_test)

--- a/docs/tutorial/multi-model.md
+++ b/docs/tutorial/multi-model.md
@@ -1,10 +1,13 @@
 # Multi-model pattern
 
-Documents with different schemes could be stored in a single collection and managed correctly. `UnionDoc` class is used for this.
+Documents with different schemas could be stored in a single collection and managed correctly. 
+`UnionDoc` class is used for this.
 
-It supports find and aggregate methods. For find, it will fetch all the found documents into the respective `Document` classes.
+It supports `find` and `aggregate` methods. 
+For `find`, it will fetch all the found documents into the respective `Document` classes.
 
-Documents that have `union_doc` in their settings still can be used in find and other queries. Queries of one such class will not see data of others.
+Documents that have `union_doc` in their settings can still be used in `find` and other queries. 
+Queries of one such class will not see the data of others.
 
 ## Example
 
@@ -47,7 +50,7 @@ await One().insert()
 await Two().insert()
 ```
 
-Find all the doc of the first type:
+Find all the documents of the first type:
 
 ```python
 docs = await One.all().to_list()

--- a/docs/tutorial/on_save_validation.md
+++ b/docs/tutorial/on_save_validation.md
@@ -1,7 +1,9 @@
 # On save validation
 
-Pydantic has very useful config to validate values on assignment - `validate_assignment = True`. But unfortunately, this is a heavy operation and doesn't fit some use cases.
-You can validate all the values before saving the document (insert, replace, save, save_changes) with beanie config `validate_on_save` instead.
+Pydantic has a very useful config to validate values on assignment - `validate_assignment = True`. 
+But, unfortunately, this is an expensive operation and doesn't fit some use cases.
+You can validate all the values before saving the document (`insert`, `replace`, `save`, `save_changes`) 
+with beanie config `validate_on_save` instead.
 
 This feature must be turned on in the `Settings` inner class explicitly:
 
@@ -14,7 +16,8 @@ class Sample(Document):
         validate_on_save = True
 ```
 
-If any field has a wrong value, it will raise an error on write operations (insert, replace, save, save_changes)
+If any field has a wrong value, 
+it will raise an error on write operations (`insert`, `replace`, `save`, `save_changes`).
 
 ```python
 sample = Sample.find_one(Sample.name == "Test")

--- a/docs/tutorial/relations.md
+++ b/docs/tutorial/relations.md
@@ -4,7 +4,7 @@ The document can contain links to other documents in their fields.
 
 *Only top-level fields are fully supported for now.*
 
-The next field types are supported:
+The following field types are supported:
 
 - `Link[...]`
 - `Optional[Link[...]]`
@@ -64,7 +64,7 @@ class House(Document):
     windows: List[Link[Window]]
 ```
 
-Optional List of the links:
+Optional list of the links:
 
 ```python
 from typing import List, Optional
@@ -86,7 +86,7 @@ class House(Document):
     yards: Optional[List[Link[Yard]]]
 ```
 
-Other link patterns are not supported for at this moment. If you need something more specific for your use-case, 
+Other link patterns are not supported at this moment. If you need something more specific for your use-case, 
 please open an issue on the GitHub page - <https://github.com/roman-right/beanie>
 
 ## Write
@@ -97,7 +97,7 @@ The following write methods support relations:
 - `replace(...)`
 - `save(...)`
 
-To apply the writing method to the linked documents, you should set the respective `link_rule` parameter
+To apply a write method to the linked documents, you should pass the respective `link_rule` argument
 
 ```python
 house.windows = [Window(x=100, y=100)]
@@ -109,7 +109,7 @@ await house.save(link_rule=WriteRules.WRITE)
 # `insert` and `replace` methods will work the same way
 ```
 
-Or Beanie can ignore internal links with the `link_rule` parameter `WriteRules.DO_NOTHING`
+Otherwise, Beanie can ignore internal links with the `link_rule` parameter `WriteRules.DO_NOTHING`
 
 ```python
 house.door.height = 3
@@ -125,7 +125,7 @@ await house.replace(link_rule=WriteRules.DO_NOTHING)
 
 ### Prefetch
 
-You can fetch linked documents on the find query step, using the parameter `fetch_links`
+You can fetch linked documents on the find query step using the `fetch_links` parameter 
 
 ```python
 houses = await House.find(
@@ -133,22 +133,22 @@ houses = await House.find(
     fetch_links=True
 ).to_list()
 ```
-
-All the find methods supported:
-
+Supported find methods:
 - `find`
 - `find_one`
 - `get`
 
-Beanie uses a single aggregation query under the hood to fetch all the linked documents. This operation is very effective.
+Beanie uses the single aggregation query under the hood to fetch all the linked documents. 
+This operation is very effective.
 
-If a direct link is referred to a non-existent document, after the fetching it will stay the object of the `Link` class.
+If a direct link is referred to a non-existent document, 
+after fetching it will remain the object of the `Link` class.
 
 Fetching will ignore non-existent documents for the list of links fields.
 
 #### Search by linked documents fields
 
-If the `fetch_links` parameter is set to `True` searching by linked documents fields is available.
+If the `fetch_links` parameter is set to `True`, search by linked documents fields is available.
 
 By field of the direct link:
 
@@ -159,7 +159,7 @@ houses = await House.find(
 ).to_list()
 ```
 
-List of links:
+By list of links:
 
 ```python
 houses = await House.find(
@@ -168,7 +168,7 @@ houses = await House.find(
 ).to_list()
 ```
 
-Search by `id` of the linked documents works using syntax:
+Search by `id` of the linked documents works using the following syntax:
 
 ```python
 houses = await House.find(
@@ -176,12 +176,13 @@ houses = await House.find(
 ).to_list()
 ```
 
-It works the same way with `fetch_links` True and False and for `find_many` and `find_one` methods.
+It works the same way with `fetch_links` equal to `True` and `False` and for `find_many` and `find_one` methods.
 
 ### On-demand fetch
 
-If you don't use prefetching, linked documents will be presented as objects of the `Link` class. You can fetch them manually then.
-To fetch all the linked documents you can use the `fetch_all_links` method
+If you don't use prefetching, linked documents will be presented as objects of the `Link` class. 
+You can fetch them manually afterwards.
+To fetch all the linked documents, you can use the `fetch_all_links` method
 
 ```python
 await house.fetch_all_links()
@@ -189,25 +190,26 @@ await house.fetch_all_links()
 
 It will fetch all the linked documents and replace `Link` objects with them.
 
-Or you can fetch a single field:
+Otherwise, you can fetch a single field:
 
 ```python
 await house.fetch_link(House.door)
 ```
 
-This will fetch the Door object and put it in the `door` field of the `house` object.
+This will fetch the Door object and put it into the `door` field of the `house` object.
 
 ## Delete
 
 Delete method works the same way as write operations, but it uses other rules.
 
-To delete all the links on the document deletion you should use the `DeleteRules.DELETE_LINKS` value for the `link_rule` parameter:
+To delete all the links on the document deletion, 
+you should use the `DeleteRules.DELETE_LINKS` value for the `link_rule` parameter:
 
 ```python
 await house.delete(link_rule=DeleteRules.DELETE_LINKS)
 ```
 
-To keep linked documents you can use the `DO_NOTHING` rule:
+To keep linked documents, you can use the `DO_NOTHING` rule:
 
 ```python
 await house.delete(link_rule=DeleteRules.DO_NOTHING)

--- a/docs/tutorial/revision.md
+++ b/docs/tutorial/revision.md
@@ -1,11 +1,12 @@
 # Revision
 
-This feature helps with concurrent operations. It stores `revision_id` together with the document and changes it on each document update. 
-If the application with the old local copy of the document tries to change it, an exception will be raised. 
-Only when the local copy will be synced with the database, the application will be allowed to change the data. 
-It helps to avoid data losses.
+This feature helps with concurrent operations. 
+It stores `revision_id` together with the document and changes it on each document update. 
+If the application with an older local copy of the document tries to change it, an exception will be raised. 
+Only when the local copy is synced with the database, the application will be allowed to change the data. 
+This helps to avoid data losses.
 
-This feature must be turned on in the `Settings` inner class explicitly:
+This feature must be explicitly turned on in the `Settings` inner class:
 
 ```python
 class Sample(Document):
@@ -16,7 +17,7 @@ class Sample(Document):
         use_revision = True
 ```
 
-Any changing operation will check if the local copy of the document has the actual `revision_id` value:
+Any changing operation will check if the local copy of the document has the up-to-date `revision_id` value:
 
 ```python
 s = await Sample.find_one(Sample.name="TestName")
@@ -26,7 +27,8 @@ s.num = 10
 await s.replace()
 ```
 
-If you want to ignore revision and apply all the changes even if the local copy is outdated, you can use the parameter `ignore_revision`:
+If you want to ignore revision and apply all the changes even if the local copy is outdated, 
+you can use the `ignore_revision` parameter:
 
 ```python
 await s.replace(ignore_revision=True)

--- a/docs/tutorial/state_management.md
+++ b/docs/tutorial/state_management.md
@@ -1,8 +1,8 @@
 # State Management
 
-Beanie can keep the document state, that synced with the database, to find local changes and save only them.
+Beanie can keep the document state synced with the database in order to find local changes and save only them.
 
-This feature must be turned on in the `Settings` inner class explicitly:
+This feature must be explicitly turned on in the `Settings` inner class:
 
 ```python
 class Sample(Document):
@@ -13,7 +13,7 @@ class Sample(Document):
         use_state_management = True
 ```
 
-To save only changed values the `save_changes()` method should be used.
+To save only changed values, the `save_changes()` method should be used.
 
 ```python
 s = await Sample.find_one(Sample.name == "Test")
@@ -21,12 +21,13 @@ s.num = 100
 await s.save_changes()
 ```
 
-The `save_changes()` method can be used only with already inserted documents.
+The `save_changes()` method can be used only with already existing documents.
 
 ## Options
 
-By default, state management will merge the changes made to nested objects, which is fine for most cases,
-as it is non-destructive, and does not re-assign the whole object is only one of its attributes changed:
+By default, state management will merge the changes made to nested objects, 
+which is fine for most cases as it is non-destructive and does not re-assign the whole object 
+if only one of its attributes changed:
 
 ```python
 from typing import Dict
@@ -49,7 +50,7 @@ await i.save_changes()
 # Keeping attribute_2
 ```
 
-However, there's some cases where you want to replace the whole object when one of its attributes changed.
+However, there are some cases where you would want to replace the whole object when one of its attributes changed.
 You can enable the `state_management_replace_objects` attribute in your model's `Settings` inner class:
 
 ```python
@@ -65,7 +66,7 @@ class Item(Document):
         state_management_replace_objects = True
 ```
 
-With this setting activated, when one attribute of the nested object is changed, the whole object will be overridden:
+With this setting activated, the whole object will be overridden when one attribute of the nested object is changed:
 
 ```python
 i = Item(name="Test", attributes={"attribute_1": 1.0, "attribute_2": 2.0})

--- a/docs/tutorial/update.md
+++ b/docs/tutorial/update.md
@@ -4,9 +4,9 @@ Now that we know how to find documents, how do we change them or delete them?
 
 ## Saving changes to existing documents
 
-The easiest way to change a document in the database is using either the `replace` or `save` methods on an altered document. 
-These methods both write the document to the database, but `replace` will raise an exception when the document does not exist yet, 
-while `save` will insert the document. 
+The easiest way to change a document in the database is to use either the `replace` or `save` method on an altered document. 
+These methods both write the document to the database, 
+but `replace` will raise an exception when the document does not exist yet, while `save` will insert the document. 
 
 Using `save()` method:
 
@@ -16,8 +16,9 @@ bar.price = 10
 await bar.save()
 ```
 
-Or similarly using `replace()` method, which throws a `ValueError` if the document does not have an `id` yet, 
-or a `beanie.exceptions.DocumentNotFound` if it does, but the `id` is not present in the collection:
+Otherwise, use the `replace()` method, which throws:
+- a `ValueError` if the document does not have an `id` yet, or
+- a `beanie.exceptions.DocumentNotFound` if it does, but the `id` is not present in the collection
 
 ```python
 bar.price = 10
@@ -27,12 +28,13 @@ except (ValueError, beanie.exceptions.DocumentNotFound):
     print("Can't replace a non existing document")
 ```
 
-Note however that these methods require multiple queries to the database and replace the entire document with the new version. 
+Note that these methods require multiple queries to the database and replace the entire document with the new version. 
 A more tailored solution can often be created by applying update queries directly on the database level.
 
 ## Update queries
 
-Update queries can be performed on the result of a `find` or `find_one` query, or on a document that was returned from an earlier query. 
+Update queries can be performed on the result of a `find` or `find_one` query, 
+or on a document that was returned from an earlier query. 
 Simpler updates can be performed using the `set`, `inc`, and `current_date` methods:
 
 ```python
@@ -47,7 +49,7 @@ More complex update operations can be performed by calling `update()` with an up
 await Product.find_one(Product.name == "Tony's").update(Set({Product.price: 3.33}))
 ```
 
-The whole list of the update query operators can be found [here](/beanie/api-documentation/operators/update).
+The whole list of the update query operators can be found [here](/api-documentation/operators/update).
 
 Native MongoDB syntax is also supported:
 
@@ -57,7 +59,7 @@ await Product.find_one(Product.name == "Tony's").update({"$set": {Product.price:
 
 ## Upsert
 
-To insert a document, where no documents were matched to the search criteria, the `upsert` method can be used:
+To insert a document when no documents are matched against the search criteria, the `upsert` method can be used:
 
 ```python
 await Product.find_one(Product.name == "Tony's").upsert(
@@ -68,7 +70,7 @@ await Product.find_one(Product.name == "Tony's").upsert(
 
 ## Deleting documents
 
-Deleting objects works just like updating them, you simply call `delete()` on the found document(s):
+Deleting objects works just like updating them, you simply call `delete()` on the found documents:
 
 ```python
 bar = await Product.find_one(Product.name == "Milka")

--- a/docs/tutorial/views.md
+++ b/docs/tutorial/views.md
@@ -1,6 +1,6 @@
 # Views
 
-Virtual views are aggregation pipelines, stored in MongoDB, that act as collections for reading operations.
+Virtual views are aggregation pipelines stored in MongoDB that act as collections for reading operations.
 You can use the `View` class the same way as `Document` for `find` and `aggregate` operations.
 
 ## Here are some examples.
@@ -77,7 +77,7 @@ print(results)
 >> [Metrics(type='Road', number=3, new=2)]
 ```
 
-Aggregate over metrics to get the number of all the new bikes:
+Aggregate over metrics to get the count of all the new bikes:
 
 ```python
 results = await Metrics.aggregate([{
@@ -92,7 +92,7 @@ print(results)
 >> [{'_id': None, 'new_total': 3}]
 ```
 
-A better result could be reached using find query aggregation syntax sugar:
+A better result can be achieved by using find query aggregation syntactic sugar:
 
 ```python
 results = await Metrics.all().sum(Metrics.new)


### PR DESCRIPTION
Fixed a couple of broken links in Tutorial section - some were pointing to outdated paths, some had non-existent anchors as targets.

Also fixed a bunch of typos and simplified several helper text points.

Added word wrapping for easier editor navigation (note - this doesn't affect the display of rendered Markdown pages).
