### PR TITLE
Implemented event type propagation to listeners

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
-      language_version: python3.10
-  - repo: https://gitlab.com/pycqa/flake8
+      language_version: python3.11
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8
@@ -16,4 +16,3 @@ repos:
           - types-click
           - types-toml
         exclude: ^tests/
-      

--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -16,6 +16,7 @@ from beanie.odm.bulk import BulkWriter
 from beanie.odm.fields import (
     PydanticObjectId,
     Indexed,
+    Unique,
     Link,
     WriteRules,
     DeleteRules,
@@ -35,6 +36,7 @@ __all__ = [
     "init_beanie",
     "PydanticObjectId",
     "Indexed",
+    "Unique",
     "TimeSeriesConfig",
     "Granularity",
     # Actions

--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -115,6 +115,7 @@ class ActionRegistry:
         :param instance: Document - object of the Document subclass
         :param event_type: EventTypes - event types
         :param action_direction: ActionDirections - before or after
+        :param exclude: list[ActionDirections | str] - list of ActionDirections or action names to skip
         """
         if action_direction in exclude:
             return
@@ -128,10 +129,13 @@ class ActionRegistry:
             if action.__name__ in exclude:
                 continue
 
+            args = (instance, event_type)
+            count = action.__code__.co_argcount  # type: ignore
+
             if inspect.iscoroutinefunction(action):
-                coros.append(action(instance))
+                coros.append(action(*args[:count]))
             elif inspect.isfunction(action):
-                action(instance)
+                action(*args[:count])
 
         await asyncio.gather(*coros)
 

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -40,6 +40,28 @@ def Indexed(typ, index_type=ASCENDING, **kwargs):
     return NewType
 
 
+def Unique(typ, index_type=ASCENDING, **kwargs):
+    optional = False
+
+    # check is type Optional and replace it with original
+    if (
+        getattr(typ, "__origin__", False) is Union
+        and type(None) in typ.__args__
+    ):
+        assert len(typ.__args__) == 2, "Index for Union is not implemented"
+        typ = typ.__args__[0]
+        optional = True
+
+    rv = Indexed(
+        typ,
+        index_type=index_type,
+        unique=True,
+        **{x: y for x, y in kwargs.items() if x != "unique"},
+    )
+
+    return Union[rv, None] if optional else rv
+
+
 class PydanticObjectId(ObjectId):
     """
     Object Id field. Compatible with Pydantic.

--- a/docs/tutorial/actions.md
+++ b/docs/tutorial/actions.md
@@ -112,3 +112,30 @@ await sample.replace(skip_actions=[After])
 # redact_name and num_change will not be executed
 await sample.replace(skip_actions[Before, 'num_change'])
 ```
+
+It is also possible to get which exactly event was triggered in case when listener function is configured to multiple ones.
+
+```python
+from beanie import Document, before_event, Insert, Replace, Update
+from beanie.odm.actions import EventTypes
+
+
+class Sample(Document):
+    num: int
+    name: str
+    last_event: str = ''
+
+    @before_event(Insert, Replace, Update)
+    def log_event(self, event: EventTypes):
+        if event is Insert:
+            print('Sample document created!')
+        elif event in (Replace, Update):
+            print('Sample document changed!')
+
+        self.last_event = str(event.value)
+
+sample = Sample()
+
+# capitalize_name will not be executed
+await sample.insert(skip_actions=['capitalize_name'])
+```

--- a/docs/tutorial/indexes.md
+++ b/docs/tutorial/indexes.md
@@ -30,14 +30,14 @@ class Sample(Document):
 
 The `Indexed` function also supports PyMongo's `IndexModel` kwargs arguments (see the [PyMongo Documentation](https://pymongo.readthedocs.io/en/stable/api/pymongo/operations.html#pymongo.operations.IndexModel) for details). 
  
-For example, to create a `unique` index:
+For example, to create a `sparse` index:
 
 ```python
 from beanie import Document, Indexed
 
 
 class Sample(Document):
-    name: Indexed(str, unique=True)
+    name: Indexed(str, sparse=True)
 ```
 
 ### Multi-field indexes
@@ -75,3 +75,34 @@ class Sample(Document):
             ),
         ]
 ```
+
+### Unique indexes
+Unique indexes can be specified in different ways:
+1) By specifying `unique=True` kwarg either in `Indexed` function or IndexModel definition inside `Settings` inner class.
+2) By using `Unique` function which is a wrapper of `Indexed` one with predefined `unique=True` kwarg.
+
+```python
+from beanie import Document, Indexed, Unique
+
+
+class Sample(Document):
+    name: Unique(str)
+    title: Indexed(str)
+```
+
+Beanie can also handle unique indexes for `Optional` fields, despite this being really tricky in mongoDB.
+
+```python
+from typing import Optional
+from beanie import Document, Indexed, Unique
+
+
+class Sample(Document):
+    name: Unique(str)
+    title: Indexed(str)
+    tag: Unique(Optional[str])
+```
+
+In python 3.11+ it can be declared like `tag: Unique(str) | None`.
+
+As well as using corresponding pydantic `Field` param: `tag: str = Field(allow_none=True)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ jinja2 = "3.0.3"
 fastapi = "^0.78.0"
 asgi-lifespan = "^1.0.1"
 httpx = "^0.23.0"
-Markdown = "3.3.5"
+Markdown = "3.3.6"
 importlib-metadata = "^4.12.0"
 
 

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 from pymongo import IndexModel
 
 from beanie import Document, Indexed, Insert, Replace, ValidateOnSave, Update
-from beanie.odm.actions import before_event, after_event, Delete
+from beanie.odm.actions import before_event, after_event, Delete, EventTypes
 from beanie.odm.fields import Link
 from beanie.odm.settings.timeseries import TimeSeriesConfig
 from beanie.odm.union_doc import UnionDoc
@@ -197,6 +197,7 @@ class DocumentWithActions(Document):
     num_1: int = 0
     num_2: int = 10
     num_3: int = 100
+    last_event: str = ""
 
     class Inner:
         inner_num_1 = 0
@@ -206,8 +207,9 @@ class DocumentWithActions(Document):
     def capitalize_name(self):
         self.name = self.name.capitalize()
 
-    @before_event([Insert, Replace])
-    async def add_one(self):
+    @before_event(Insert, Replace)
+    async def add_one(self, event: EventTypes = None):
+        self.last_event = str(event.value)
         self.num_1 += 1
 
     @after_event(Insert)
@@ -240,6 +242,7 @@ class DocumentWithActions2(Document):
     num_1: int = 0
     num_2: int = 10
     num_3: int = 100
+    last_event: str = ""
 
     class Inner:
         inner_num_1 = 0
@@ -250,7 +253,8 @@ class DocumentWithActions2(Document):
         self.name = self.name.capitalize()
 
     @before_event(Insert, Replace)
-    async def add_one(self):
+    async def add_one(self, event: EventTypes = None):
+        self.last_event = str(event.value)
         self.num_1 += 1
 
     @after_event(Insert)

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -18,7 +18,15 @@ from pydantic.color import Color
 from pydantic import BaseModel, Field
 from pymongo import IndexModel
 
-from beanie import Document, Indexed, Insert, Replace, ValidateOnSave, Update
+from beanie import (
+    Document,
+    Indexed,
+    Insert,
+    Replace,
+    ValidateOnSave,
+    Update,
+    Unique,
+)
 from beanie.odm.actions import before_event, after_event, Delete, EventTypes
 from beanie.odm.fields import Link
 from beanie.odm.settings.timeseries import TimeSeriesConfig
@@ -88,6 +96,18 @@ class DocumentTestModelWithSimpleIndex(Document):
     test_int: Indexed(int)
     test_list: List[SubDocument]
     test_str: Indexed(str, index_type=pymongo.TEXT)
+
+
+class DocumentTestModelWithUniqueIndex(Document):
+    test_int: Unique(int)
+    test_list: List[SubDocument]
+    test_str: Indexed(str, index_type=pymongo.TEXT)
+
+
+class DocumentTestModelWithOptionalUniqueIndex(Document):
+    test_int: Unique(Optional[int])
+    test_list: List[SubDocument]
+    test_str: Unique(Optional[str], index_type=pymongo.TEXT) = None
 
 
 class DocumentTestModelWithIndexFlags(Document):


### PR DESCRIPTION
This feature allows to declare functions that are event listeners with additional `event` parameter.
Example:

```python
class Sample(Document):
    num: int
    name: str
    last_event: str = ''

    @before_event(Insert, Replace, Update)
    def log_event(self, event: EventTypes):
        if event is Insert:
            print('Sample document created!')
        elif event in (Replace, Update):
            print('Sample document changed!')

        self.last_event = str(event.value)
```

This implementation is backward compatible, any functions will be called properly based on their signatures.

_Inspired by DaveRGA's question on Beanie Discord server at Nov, 17 2022._