### PR TITLE
Allow change class_id and use name settings in UnionDoc

### DIFF
--- a/beanie/odm/interfaces/find.py
+++ b/beanie/odm/interfaces/find.py
@@ -427,5 +427,5 @@ class FindInterface:
                 )
 
         if cls.get_settings().union_doc:
-            args += ({"_class_id": cls.__name__},)
+            args += ({"_class_id": cls.get_settings().class_id},)
         return args

--- a/beanie/odm/interfaces/find.py
+++ b/beanie/odm/interfaces/find.py
@@ -415,11 +415,11 @@ class FindInterface:
             and cls._inheritance_inited
         ):
             if not with_children:
-                args += ({"_class_id": cls._class_id},)
+                args += ({cls.get_settings().class_id: cls._class_id},)
             else:
                 args += (
                     {
-                        "_class_id": {
+                        cls.get_settings().class_id: {
                             "$in": [cls._class_id]
                             + [cname for cname in cls._children.keys()]
                         }

--- a/beanie/odm/interfaces/find.py
+++ b/beanie/odm/interfaces/find.py
@@ -405,7 +405,7 @@ class FindInterface:
             (
                 True
                 for a in args
-                if isinstance(a, Iterable) and "_class_id" in a
+                if isinstance(a, Iterable) and cls.get_settings().class_id in a
             )
         ):
             return args

--- a/beanie/odm/interfaces/find.py
+++ b/beanie/odm/interfaces/find.py
@@ -427,5 +427,5 @@ class FindInterface:
                 )
 
         if cls.get_settings().union_doc:
-            args += ({"_class_id": cls.get_settings().class_id},)
+            args += ({"cls.get_settings().class_id": cls.get_settings().name or cls.__name__},)
         return args

--- a/beanie/odm/interfaces/find.py
+++ b/beanie/odm/interfaces/find.py
@@ -427,5 +427,5 @@ class FindInterface:
                 )
 
         if cls.get_settings().union_doc:
-            args += ({"cls.get_settings().class_id": cls.get_settings().name or cls.__name__},)
+            args += ({cls.get_settings().class_id: cls.get_settings().union_doc_alias},)
         return args

--- a/beanie/odm/settings/base.py
+++ b/beanie/odm/settings/base.py
@@ -18,6 +18,7 @@ class ItemSettings(BaseModel):
     motor_collection: Optional[AsyncIOMotorCollection] = None
 
     union_doc: Optional[Type] = None
+    union_doc_alias: Optional[str] = None
     class_id: str = "_class_id"
 
     is_root: bool = False

--- a/beanie/odm/settings/base.py
+++ b/beanie/odm/settings/base.py
@@ -18,6 +18,7 @@ class ItemSettings(BaseModel):
     motor_collection: Optional[AsyncIOMotorCollection] = None
 
     union_doc: Optional[Type] = None
+    class_id: str = "_class_id"
 
     is_root: bool = False
 

--- a/beanie/odm/settings/union_doc.py
+++ b/beanie/odm/settings/union_doc.py
@@ -2,4 +2,5 @@ from beanie.odm.settings.base import ItemSettings
 
 
 class UnionDocSettings(ItemSettings):
+    class_id: str = "_class_id"
     ...

--- a/beanie/odm/settings/union_doc.py
+++ b/beanie/odm/settings/union_doc.py
@@ -2,5 +2,4 @@ from beanie.odm.settings.base import ItemSettings
 
 
 class UnionDocSettings(ItemSettings):
-    class_id: str = "_class_id"
     ...

--- a/beanie/odm/union_doc.py
+++ b/beanie/odm/union_doc.py
@@ -23,14 +23,14 @@ class UnionDoc(
         return cls._settings
 
     @classmethod
-    def register_doc(cls, doc_model: Type):
+    def register_doc(cls, name: str, doc_model: Type):
         if cls._document_models is None:
             cls._document_models = {}
 
         if cls._is_inited is False:
             raise UnionDocNotInited
 
-        cls._document_models[doc_model.__name__] = doc_model
+        cls._document_models[name] = doc_model
         return cls.get_settings().name
 
     @classmethod

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -92,9 +92,9 @@ class Encoder:
         link_fields = obj.get_link_fields()
         obj_dict: Dict[str, Any] = {}
         if obj.get_settings().union_doc is not None:
-            obj_dict["_class_id"] = obj.__class__.__name__
+            obj_dict[obj.get_settings().class_id] = obj.get_settings().union_doc_alias or obj.__class__.__name__
         if obj._inheritance_inited:
-            obj_dict["_class_id"] = obj._class_id
+            obj_dict[obj.get_settings().class_id] = obj._class_id
 
         for k, o in obj._iter(to_dict=False, by_alias=self.by_alias):
             if k not in self.exclude:

--- a/beanie/odm/utils/init.py
+++ b/beanie/odm/utils/init.py
@@ -237,6 +237,7 @@ class Initializer:
             document_settings.name = document_settings.union_doc.register_doc(
                 name, cls
             )
+            document_settings.union_doc_alias = name
 
         # set a name
 

--- a/beanie/odm/utils/init.py
+++ b/beanie/odm/utils/init.py
@@ -233,8 +233,9 @@ class Initializer:
         # register in the Union Doc
 
         if document_settings.union_doc is not None:
+            name = cls.get_settings().name or cls.__name__
             document_settings.name = document_settings.union_doc.register_doc(
-                cls
+                name, cls
             )
 
         # set a name

--- a/beanie/odm/utils/parsing.py
+++ b/beanie/odm/utils/parsing.py
@@ -41,8 +41,8 @@ def parse_obj(
         and model._inheritance_inited  # type: ignore
     ):
         if isinstance(data, dict):
-            class_name = data.get("_class_id")
-        elif hasattr(data, "_class_id"):
+            class_name = data.get(model.get_settings().class_id)
+        elif hasattr(data, model.get_settings().class_id):
             class_name = data._class_id
         else:
             class_name = None

--- a/beanie/odm/utils/parsing.py
+++ b/beanie/odm/utils/parsing.py
@@ -24,7 +24,7 @@ def parse_obj(
             raise UnionHasNoRegisteredDocs
 
         if isinstance(data, dict):
-            class_name = data["_class_id"]
+            class_name = data[model.get_settings().class_id]
         else:
             class_name = data._class_id
 

--- a/docs/tutorial/multi-model.md
+++ b/docs/tutorial/multi-model.md
@@ -20,13 +20,15 @@ from beanie import Document, UnionDoc
 class Parent(UnionDoc):  # Union
     class Settings:
         name = "union_doc_collection"  # Collection name
-
+        class_id = "_class_id"  # _class_id is default beanie internal field used to filter children Documents
+        
         
 class One(Document):
     int_field: int = 0
     shared: int = 0        
 
     class Settings:
+        name = "One" # Child collection name
         union_doc = Parent
 
 

--- a/docs/tutorial/multi-model.md
+++ b/docs/tutorial/multi-model.md
@@ -28,8 +28,8 @@ class One(Document):
     shared: int = 0        
 
     class Settings:
-        name = "One" # Child collection name
         union_doc = Parent
+        union_doc_alias = "One" # Name used to filer union document 'One', default to class name
 
 
 class Two(Document):

--- a/docs/tutorial/multi-model.md
+++ b/docs/tutorial/multi-model.md
@@ -28,8 +28,8 @@ class One(Document):
     shared: int = 0        
 
     class Settings:
+        name = "One" # Name used to filer union document 'One', default to class name
         union_doc = Parent
-        union_doc_alias = "One" # Name used to filer union document 'One', default to class name
 
 
 class Two(Document):

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -81,6 +81,8 @@ class DocumentTestModel(Document):
         cache_expiration_time = datetime.timedelta(seconds=10)
         cache_capacity = 5
         use_state_management = True
+        name = "different_name"
+        class_id = "different_class_id"
 
 
 class DocumentTestModelWithCustomCollectionName(Document):
@@ -434,6 +436,7 @@ class DocumentForEncodingTestDate(Document):
 class DocumentUnion(UnionDoc):
     class Settings:
         name = "multi_model"
+        class_id = "123"
 
 
 class DocumentMultiModelOne(Document):
@@ -442,6 +445,8 @@ class DocumentMultiModelOne(Document):
 
     class Settings:
         union_doc = DocumentUnion
+        name = "multi_one"
+        class_id = "123"
 
 
 class DocumentMultiModelTwo(Document):
@@ -451,6 +456,8 @@ class DocumentMultiModelTwo(Document):
 
     class Settings:
         union_doc = DocumentUnion
+        name = "multi_two"
+        class_id = "123"
 
 
 class YardWithRevision(Document):

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -81,8 +81,6 @@ class DocumentTestModel(Document):
         cache_expiration_time = datetime.timedelta(seconds=10)
         cache_capacity = 5
         use_state_management = True
-        name = "different_name"
-        class_id = "different_class_id"
 
 
 class DocumentTestModelWithCustomCollectionName(Document):
@@ -92,6 +90,7 @@ class DocumentTestModelWithCustomCollectionName(Document):
 
     class Settings:
         name = "custom"
+        class_id = "different_class_id"
 
 
 class DocumentTestModelWithSimpleIndex(Document):


### PR DESCRIPTION
Beanie is all sound and good until there is a need to connect to existing DB where beanie is/was not used.
For instance, one might have SNS -> SQS -> lambda (that uses any other client other than beanie) -> DocDB / Mongo. 
In case like this, the existing data would not have beanie's internal data field such as '_class_id".

This makes switching to Beanie difficult as it requires full DB migration, especially if DB is used for event-sourcing. 

This PR allows (1) custom internal data field name to be set and (2) custom name to be set in Union doc children classes.

Usage:
```
class Parent(UnionDoc):
    class Settings:
        class_id = "event_type" <-
        name = "eventsource"

class ChildCreated(Document):
    event_type: Literal["created"] = "created" <- event_type is used instead of _class_id 
    sent_at: datetime

    class Settings:
        name = "created" <- This was option was ignored before
        union_doc = Parent

class ChildDeleted(Document):
    event_type: Literal["created"] = "deleted" <- event_type is used instead of _class_id 
    sent_at: datetime

    class Settings:
        name = "deleted" <- This was option was ignored before
        union_doc = Parent
```

Example:

Schema
```
class Parent(UnionDoc):
    class Settings:
        class_id = "event_type"
        name = "collection"


class One(Document):
    test: int

    class Settings:
        name = "two"
        class_id = "event_type"
        union_doc = Parent
        
 class Two(Document): <- without union_doc
    test: int

    class Settings:
        name = "three"
        class_id = "event_type"

```

Test
```
In [1]: await db.One(test=1).insert()
Out[1]: One(id=ObjectId('63ae1890edab780d45df0b07'), revision_id=None, test=1)

pymongo
In [17]: list(c["db"]["collection"].find({'test': 1}))
Out[17]: [{'_id': ObjectId('63ae1890edab780d45df0b07'), 'event_type': 'two', 'test': 1}]

In [1]: await db.Two(test=3).insert()
Out[1]: Two(id=ObjectId('63ae19cd8e684a4cd769fb1f'), revision_id=None, test=3)

pymongo
In [23]: list(c["db"]["three"].find({'test': 3}))
Out[23]: [{'_id': ObjectId('63ae19cd8e684a4cd769fb1f'), 'test': 3}]

```

---

FYI, https://github.com/roman-right/beanie/pull/206 this PR was not reviewed for a year so I closed it..