### PR TITLE
FIX: already inserted Links will will throw DuplicateKeyError on insert of wrapping doc

### DIFF
--- a/.github/workflows/github-actions-lint.yml
+++ b/.github/workflows/github-actions-lint.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ 3.10.5 ]
-        os: [ ubuntu-18.04 ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/github-actions-mypy.yml
+++ b/.github/workflows/github-actions-mypy.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ 3.10.5 ]
-        os: [ ubuntu-18.04 ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -10,7 +10,7 @@ jobs:
         poetry-version: [ 1.2 ]
         mongodb-version: [ 4.4, 5.0 ]
         pydantic-version: [1.10.0]
-        os: [ ubuntu-18.04 ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -26,7 +26,7 @@ from beanie.odm.documents import Document
 from beanie.odm.views import View
 from beanie.odm.union_doc import UnionDoc
 
-__version__ = "1.16.7"
+__version__ = "1.16.8"
 __all__ = [
     # ODM
     "Document",

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -216,7 +216,7 @@ class Document(
                         LinkTypes.OPTIONAL_DIRECT,
                     ]:
                         if isinstance(value, Document):
-                            await value.insert(link_rule=WriteRules.WRITE)
+                            await value.save(link_rule=WriteRules.WRITE)
                     if field_info.link_type in [
                         LinkTypes.LIST,
                         LinkTypes.OPTIONAL_LIST,
@@ -224,9 +224,7 @@ class Document(
                         if isinstance(value, List):
                             for obj in value:
                                 if isinstance(obj, Document):
-                                    await obj.insert(
-                                        link_rule=WriteRules.WRITE
-                                    )
+                                    await obj.save(link_rule=WriteRules.WRITE)
 
         result = await self.get_motor_collection().insert_one(
             get_dict(self, to_db=True), session=session
@@ -774,7 +772,10 @@ class Document(
     @saved_state_needed
     @previous_saved_state_needed
     def has_changed(self) -> bool:
-        if self._previous_saved_state is None or self._previous_saved_state == self._saved_state:
+        if (
+            self._previous_saved_state is None
+            or self._previous_saved_state == self._saved_state
+        ):
             return False
         return True
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,17 @@
 
 Beanie project
 
+## [1.16.8] - 2022-01-05
+
+### Fix
+
+- Already inserted Links will throw DuplicateKeyError on insert of wrapping doc
+
+### Implementation
+
+- Author - [noaHson86](https://github.com/noaHson86)
+- PR <https://github.com/roman-right/beanie/pull/469>
+
 ## [1.16.7] - 2023-01-03
 
 ### Fix
@@ -1227,3 +1238,5 @@ how specific type should be presented in the database
 [1.16.6]: https://pypi.org/project/beanie/1.16.6
 
 [1.16.7]: https://pypi.org/project/beanie/1.16.7
+
+[1.16.8]: https://pypi.org/project/beanie/1.16.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beanie"
-version = "1.16.7"
+version = "1.16.8"
 description = "Asynchronous Python ODM for MongoDB"
 authors = ["Roman <roman-right@protonmail.com>"]
 license = "Apache-2.0"

--- a/tests/odm/test_relations.py
+++ b/tests/odm/test_relations.py
@@ -151,6 +151,20 @@ class TestInsert:
         await house.insert(link_rule=WriteRules.WRITE)
         house.json()
 
+    async def test_multi_insert_links(self):
+        house = House(name="random", windows=[], door=Door())
+        window = await Window(x=13, y=23).insert()
+        assert window.id
+        house.windows.append(window)
+
+        house = await house.insert(link_rule=WriteRules.WRITE)
+        new_window = Window(x=11, y=22)
+        house.windows.append(new_window)
+        house = await house.save(link_rule=WriteRules.WRITE)
+        for win in house.windows:
+            assert isinstance(win, Window)
+            assert win.id
+
 
 class TestFind:
     async def test_prefetch_find_many(self, houses):

--- a/tests/odm/test_state_management.py
+++ b/tests/odm/test_state_management.py
@@ -82,10 +82,17 @@ async def house(house_not_inserted):
 
 class TestStateManagement:
     async def test_use_state_management_property(self):
-        assert DocumentWithTurnedOnStateManagement.use_state_management() is True
-        assert DocumentWithTurnedOffStateManagement.use_state_management() is False
+        assert (
+            DocumentWithTurnedOnStateManagement.use_state_management() is True
+        )
+        assert (
+            DocumentWithTurnedOffStateManagement.use_state_management()
+            is False
+        )
 
-    async def test_state_with_decimal_field(self, ):
+    async def test_state_with_decimal_field(
+        self,
+    ):
         await StateAndDecimalFieldModel(amt=10.01).insert()
         await StateAndDecimalFieldModel.all().to_list()
 
@@ -292,15 +299,21 @@ class TestStateManagement:
             saved_doc_default.num_1 = 10000
 
             saved_doc_default.internal.change_private()
-            assert saved_doc_default.internal.get_private() == "PRIVATE_CHANGED"
+            assert (
+                saved_doc_default.internal.get_private() == "PRIVATE_CHANGED"
+            )
 
             await saved_doc_default.save_changes()
 
             assert saved_doc_default.get_saved_state()["num_1"] == 10000
             assert saved_doc_default.get_previous_saved_state() is None
-            assert saved_doc_default.internal.get_private() == "PRIVATE_CHANGED"
+            assert (
+                saved_doc_default.internal.get_private() == "PRIVATE_CHANGED"
+            )
 
-            new_doc = await DocumentWithTurnedOnStateManagement.get(saved_doc_default.id)
+            new_doc = await DocumentWithTurnedOnStateManagement.get(
+                saved_doc_default.id
+            )
             assert new_doc.num_1 == 10000
 
         async def test_save_changes_previous(self, saved_doc_previous):
@@ -310,14 +323,20 @@ class TestStateManagement:
             saved_doc_previous.num_1 = 10000
 
             saved_doc_previous.internal.change_private()
-            assert saved_doc_previous.internal.get_private() == "PRIVATE_CHANGED"
+            assert (
+                saved_doc_previous.internal.get_private() == "PRIVATE_CHANGED"
+            )
 
             await saved_doc_previous.save_changes()
             assert saved_doc_previous.get_saved_state()["num_1"] == 10000
             assert saved_doc_previous.get_previous_saved_state()["num_1"] == 1
-            assert saved_doc_previous.internal.get_private() == "PRIVATE_CHANGED"
+            assert (
+                saved_doc_previous.internal.get_private() == "PRIVATE_CHANGED"
+            )
 
-            new_doc = await DocumentWithTurnedOnSavePrevious.get(saved_doc_previous.id)
+            new_doc = await DocumentWithTurnedOnSavePrevious.get(
+                saved_doc_previous.id
+            )
             assert new_doc.num_1 == 10000
 
         async def test_fetch_save_changes(self, house):
@@ -360,7 +379,9 @@ class TestStateManagement:
                 assert doc.get_previous_saved_state() is None
 
         async def test_insert(self, state_without_id):
-            doc = DocumentWithTurnedOnStateManagement.parse_obj(state_without_id)
+            doc = DocumentWithTurnedOnStateManagement.parse_obj(
+                state_without_id
+            )
             assert doc.get_saved_state() is None
             await doc.insert()
             new_state = doc.get_saved_state()

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.16.7"
+    assert __version__ == "1.16.8"


### PR DESCRIPTION
This is a quick fix for DuplicateKeyError on insert. a test is added that will fail, 
when you revert the changes in documents.py. Im not sure if i like the amount of calls, 
that could be possibly made.
The try/except + replace/insert in save could be possibly replaced with an upsert.

