### PR TITLE
fix: make `revision_id` not show in schema

### DIFF
--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -997,3 +997,9 @@ class Document(
         ) -> None:
             for field_name in model._hidden_fields:
                 schema.get("properties", {}).pop(field_name, None)
+
+            props = {}
+            for k, v in schema.get('properties', {}).items():
+                if not v.get("hidden", False):
+                    props[k] = v
+            schema["properties"] = props

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -995,11 +995,8 @@ class Document(
         def schema_extra(
             schema: Dict[str, Any], model: Type["Document"]
         ) -> None:
-            for field_name in model._hidden_fields:
-                schema.get("properties", {}).pop(field_name, None)
-
             props = {}
-            for k, v in schema.get('properties', {}).items():
+            for k, v in schema.get("properties", {}).items():
                 if not v.get("hidden", False):
                     props[k] = v
             schema["properties"] = props


### PR DESCRIPTION
Fix #418

This is my first ever pull request (will hopefully not be the last), so please be kind!  :sweat_smile: 

I basically found [this solution](https://github.com/tiangolo/fastapi/issues/1378#issuecomment-1374968471) and applied it to the `Document` class, and it worked at first try. So, thanks @Xenthys!

Also, @roman-right, correct me if I am wrong but I believe the previous two lines: 
```python
            for field_name in model._hidden_fields:
                schema.get("properties", {}).pop(field_name, None)
```
become redundant. I believe they were trying to accomplish the same thing, but it seems that it only works once the doc is initialized.

So, if you agree @roman-right, I can remove the redundancy before merging. 
