### PR TITLE
Fix typing in 'Document.get(...)'

### DIFF
--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -147,7 +147,7 @@ class Document(
     @classmethod
     async def get(
         cls: Type["DocType"],
-        document_id: PydanticObjectId,
+        document_id: Any,
         session: Optional[ClientSession] = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,


### PR DESCRIPTION
Fixed type of `document_id` in `get()` function, it should be `Any` rather than `PydanticObjectId`