### PR TITLE
Feat: Add box operator

### DIFF
--- a/beanie/odm/operators/find/geospatial.py
+++ b/beanie/odm/operators/find/geospatial.py
@@ -138,6 +138,62 @@ class GeoWithin(BaseFindGeospatialOperator):
         }
 
 
+class Box(BaseFindGeospatialOperator):
+    """
+    `$box` query operator
+
+    Example:
+
+    ```python
+    class GeoObject(BaseModel):
+        type: str = "Point"
+        coordinates: Tuple[float, float]
+
+    class Place(Document):
+        geo: GeoObject
+
+        class Collection:
+            name = "places"
+            indexes = [
+                [("geo", pymongo.GEOSPHERE)],  # GEO index
+            ]
+
+    Box(Place.geo, lower_left=[10,12], upper_right=[15,20])
+    ```
+
+    Will return query object like
+
+    ```python
+    {
+        "geo": {
+            "$geoWithin": {
+                "$box": [[10, 12], [15, 20]]
+            }
+        }
+    }
+    ```
+
+    MongoDB doc:
+    <https://docs.mongodb.com/manual/reference/operator/query/box/>
+    """
+
+    def __init__(
+        self, field, lower_left: List[float], upper_right: List[float]
+    ):
+        self.field = field
+        self.coordinates = [lower_left, upper_right]
+
+    @property
+    def query(self):
+        return {
+            self.field: {
+                "$geoWithin": {
+                    "$box": self.coordinates
+                }
+            }
+        }
+
+
 class Near(BaseFindGeospatialOperator):
     """
     `$near` query operator

--- a/beanie/operators.py
+++ b/beanie/operators.py
@@ -28,6 +28,7 @@ from beanie.odm.operators.find.geospatial import (
     GeoIntersects,
     GeoWithinTypes,
     GeoWithin,
+    Box,
     Near,
     NearSphere,
 )
@@ -87,6 +88,7 @@ __all__ = [
     "GeoIntersects",
     "GeoWithinTypes",
     "GeoWithin",
+    "Box",
     "Near",
     "NearSphere",
     # Logical

--- a/tests/odm/operators/find/test_geospatial.py
+++ b/tests/odm/operators/find/test_geospatial.py
@@ -1,4 +1,5 @@
 from beanie.odm.operators.find.geospatial import (
+    Box,
     GeoIntersects,
     GeoWithin,
     Near,
@@ -34,6 +35,17 @@ async def test_geo_within():
                     "type": "Polygon",
                     "coordinates": [[1, 1], [2, 2], [3, 3]],
                 }
+            }
+        }
+    }
+
+
+async def test_box():
+    q = Box(Sample.geo, lower_left=[1,3], upper_right=[2,4])
+    assert q == {
+        "geo": {
+            "$geoWithin": {
+                "$box": [[1,3], [2,4]]
             }
         }
     }


### PR DESCRIPTION
Hi, 
I am currently using beanie for a project and was missing a builtin class for the `$box` operator.
So... here it is :)
Let me know, if this looks alright. 
If you dont like the `lower_left` and `upper_right` way of doing it, we could also do it simply with `coordinates` expecting a list with two tuples.

If you think, people might be interested in the other geospatial operators (center, etc.), I could also implement those. Just weren't part of my use case so far :)