### PR TITLE
Reworked DB version handling, added verbose error for nested links incompatibility

### DIFF
--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ 3.7, 3.8, 3.9, 3.10.9, 3.11 ]
-        mongodb-version: [ 4.4, 5.0 ]
+        mongodb-version: [ 4.2, 4.4, 5.0 ]
         pydantic-version: [ 1.10.0 ]
     runs-on: ubuntu-latest
     steps:

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -79,6 +79,7 @@ from beanie.odm.operators.update.general import (
 from beanie.odm.queries.update import UpdateMany, UpdateResponse
 from beanie.odm.settings.document import DocumentSettings
 from beanie.odm.utils.dump import get_dict, get_top_level_nones
+from beanie.odm.utils.general import DatabaseVersion
 from beanie.odm.utils.parsing import merge_models
 from beanie.odm.utils.self_validation import validate_self_before
 from beanie.odm.utils.state import (
@@ -135,7 +136,9 @@ class Document(
     _document_settings: ClassVar[Optional[DocumentSettings]] = None
 
     # Database
-    _database_major_version: ClassVar[int] = 4
+    _database_version: ClassVar[DatabaseVersion] = DatabaseVersion.from_str(
+        "4"
+    )
 
     # Other
     _hidden_fields: ClassVar[Set[str]] = set()

--- a/beanie/odm/utils/compatibility.py
+++ b/beanie/odm/utils/compatibility.py
@@ -1,0 +1,11 @@
+from beanie.odm.utils.general import DatabaseVersion
+
+
+def supports_timeseries(database_version: DatabaseVersion) -> bool:
+    return database_version.major >= 5
+
+
+def supports_nested_links(database_version: DatabaseVersion) -> bool:
+    return database_version.major > 4 or (
+        database_version.major == 4 and database_version.minor >= 4
+    )

--- a/beanie/odm/utils/general.py
+++ b/beanie/odm/utils/general.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+
+from beanie.exceptions import MongoDBVersionError
+
+
+class DatabaseVersion(BaseModel):
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def from_str(cls, version: str) -> "DatabaseVersion":
+        parts = version.split(".")
+        if not parts[0]:
+            raise MongoDBVersionError("MongoDB version can't be empty")
+        return DatabaseVersion(
+            major=parts[0],
+            minor=parts[1] if len(parts) > 1 else 0,
+            patch=parts[2] if len(parts) > 2 else 0,
+        )
+
+    def __str__(self):
+        return f"{self.major}.{self.minor}.{self.patch}"

--- a/docs/tutorial/relations.md
+++ b/docs/tutorial/relations.md
@@ -2,7 +2,9 @@
 
 The document can contain links to other documents in their fields.
 
-*Only top-level fields are fully supported for now.*
+> **Note:** Only top-level fields are fully supported for now
+
+> **Warning:** Nested links fetching is supported only for MongoDB version *4.4* or newer
 
 The following field types are supported:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import motor.motor_asyncio
 import pytest
 from pydantic import BaseSettings
 
+from beanie.odm.utils.general import DatabaseVersion
+
 
 class Settings(BaseSettings):
     mongodb_dsn: str = "mongodb://localhost:27017/beanie_db"
@@ -21,3 +23,9 @@ def cli(settings, loop):
 @pytest.fixture()
 def db(cli, settings, loop):
     return cli[settings.mongodb_db_name]
+
+
+@pytest.fixture()
+async def database_version(db):
+    build_info = await db.command({"buildInfo": 1})
+    return DatabaseVersion.from_str(build_info["version"])

--- a/tests/odm/test_timeseries_collection.py
+++ b/tests/odm/test_timeseries_collection.py
@@ -2,20 +2,19 @@ import pytest
 
 from beanie import init_beanie
 from beanie.exceptions import MongoDBVersionError
+from beanie.odm.utils.compatibility import supports_timeseries
+from beanie.odm.utils.general import DatabaseVersion
 from tests.odm.models import DocumentWithTimeseries
 
 
-async def test_timeseries_collection(db):
-    build_info = await db.command({"buildInfo": 1})
-    mongo_version = build_info["version"]
-    major_version = int(mongo_version.split(".")[0])
-    if major_version < 5:
+async def test_timeseries_collection(db, database_version: DatabaseVersion):
+    if not supports_timeseries(database_version):
         with pytest.raises(MongoDBVersionError):
             await init_beanie(
                 database=db, document_models=[DocumentWithTimeseries]
             )
 
-    if major_version >= 5:
+    if supports_timeseries(database_version):
         await init_beanie(
             database=db, document_models=[DocumentWithTimeseries]
         )


### PR DESCRIPTION
Added nested links incompatibility exception to query builder, along with a warning note in documentation ("Relations" tutorial section).

Added a fixture for easier database version parsing.

Moved DB version handling to a dedicated file, added compatibility utility methods in order to reduce hardcoded version matching.

Note: No unit tests have been added since the whole `tests/odm/test_relations.py` file is going to break if tested against MongoDB version that's older than 4.4. Since there is no test environment with an earlier MongoDB version, I don't find it necessary to add any workarounds there. A blanket pytest.skip might do the trick