### PR TITLE
fix(docs): documentation for ElemMatch

### DIFF
--- a/beanie/odm/operators/find/array.py
+++ b/beanie/odm/operators/find/array.py
@@ -54,13 +54,13 @@ class ElemMatch(BaseFindArrayOperator):
     class Sample(Document):
         results: List[int]
 
-    ElemMatch(Sample.results, [80, 85])
+    ElemMatch(Sample.results, {"$in": [80, 85]})
     ```
 
     Will return query object like
 
     ```python
-    {"results": {"$elemMatch": [80, 85]}}
+    {"results": {"$elemMatch": {"$in": [80, 85]}}}
     ```
 
     MongoDB doc:


### PR DESCRIPTION
The version with just matching on an array of values isn't possible. elemMatch needs an object (dict) as correctly specified in the type annotation.
I guess, the old version of the docstring was copy-pasted from the Any operator above :)