### PR TITLE
refactor: use TypeAdapter instead deprecated parse_obj_as

### DIFF
--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -20,7 +20,7 @@ from pydantic import (
     ValidationError,
     PrivateAttr,
     Field,
-    parse_obj_as,
+    TypeAdapter,
 )
 from pydantic.class_validators import root_validator
 from pydantic.main import BaseModel
@@ -247,7 +247,9 @@ class Document(
         )
         new_id = result.inserted_id
         if not isinstance(new_id, self.__fields__["id"].type_):
-            new_id = parse_obj_as(self.__fields__["id"].type_, new_id)
+            new_id = TypeAdapter(self.__fields__["id"].type_).validate_python(
+                new_id
+            )
         self.id = new_id
         return self
 
@@ -309,7 +311,6 @@ class Document(
         link_rule: WriteRules = WriteRules.DO_NOTHING,
         **pymongo_kwargs,
     ) -> InsertManyResult:
-
         """
         Insert many documents to the collection
 
@@ -904,7 +905,6 @@ class Document(
                         elif isinstance(field_value, dict) and isinstance(
                             old_dict.get(field_name), dict
                         ):
-
                             field_data = self._collect_updates(
                                 old_dict.get(field_name),  # type: ignore
                                 field_value,

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -17,7 +17,7 @@ from typing import OrderedDict as OrderedDictType
 
 from bson import ObjectId, DBRef
 from bson.errors import InvalidId
-from pydantic import BaseModel, parse_obj_as
+from pydantic import BaseModel, TypeAdapter
 from pydantic.fields import ModelField
 from pydantic.json import ENCODERS_BY_TYPE
 from pymongo import ASCENDING
@@ -258,7 +258,9 @@ class Link(Generic[T]):
             return v
         if isinstance(v, dict) or isinstance(v, BaseModel):
             return parse_obj(model_class, v)
-        new_id = parse_obj_as(model_class.__fields__["id"].type_, v)
+        new_id = TypeAdapter(
+            model_class.__fields__["id"].type_
+        ).validate_python(v)
         ref = DBRef(collection=model_class.get_collection_name(), id=new_id)
         return cls(ref=ref, model_class=model_class)
 


### PR DESCRIPTION
In pydantic parse_obj_as is deprecated and use TypeAdapter instead.