### PR TITLE
DocumentSettings ignore extra fields Pydantic Validation

### DIFF
--- a/beanie/odm/settings/document.py
+++ b/beanie/odm/settings/document.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from pydantic import Field
+from pydantic import Field, Extra
 
 from beanie.odm.fields import IndexModelField
 from beanie.odm.settings.base import ItemSettings
@@ -25,3 +25,4 @@ class DocumentSettings(ItemSettings):
 
     class Config:
         arbitrary_types_allowed = True
+        extra = Extra.ignore


### PR DESCRIPTION
When setting the default pydantic Config to forbig extra fields:

```py
from pydantic import config, Extra
config.BaseConfig.extra = Extra.forbid
```

Beanie throws errors at document initialization due to the following: ValidationError: 4 validation errors for DocumentSettings __dict__
  extra fields not permitted (type=value_error.extra)
__doc__
  extra fields not permitted (type=value_error.extra)
__module__
  extra fields not permitted (type=value_error.extra)
__weakref__
  extra fields not permitted (type=value_error.extra)


The proposed commit fixes the issue. 
Not sure if ideal, or if there is any caveats with this solution