### PR TITLE
Fix get_field_type & generalize extract_id_class

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -31,7 +31,7 @@ from beanie.odm.documents import Document
 from beanie.odm.views import View
 from beanie.odm.union_doc import UnionDoc
 
-__version__ = "1.22.1"
+__version__ = "1.22.2"
 __all__ = [
     # ODM
     "Document",

--- a/beanie/odm/utils/pydantic.py
+++ b/beanie/odm/utils/pydantic.py
@@ -22,7 +22,7 @@ def get_field_type(field):
     if IS_PYDANTIC_V2:
         return field.annotation
     else:
-        return field.type_
+        return field.outer_type_
 
 
 def get_model_fields(model):

--- a/beanie/odm/utils/typing.py
+++ b/beanie/odm/utils/typing.py
@@ -5,26 +5,18 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import get_args, get_origin
 
-from typing import Optional, Union, Type, Any
+from typing import Type, Any
 import inspect
 
 
 def extract_id_class(annotation) -> Type[Any]:
+    if get_origin(annotation) is not None:
+        try:
+            annotation = next(
+                arg for arg in get_args(annotation) if arg is not type(None)
+            )
+        except StopIteration:
+            annotation = None
     if inspect.isclass(annotation):
         return annotation
-
-    elif get_origin(annotation) is Union:
-        args = get_args(annotation)
-        for arg in args:
-            if inspect.isclass(arg) and arg is not type(None):
-                return arg
-        raise ValueError("Unknown annotation: {}".format(annotation))
-
-    elif get_origin(annotation) is Optional:
-        arg = get_args(annotation)[0]
-        if inspect.isclass(arg):
-            return arg
-        else:
-            raise ValueError("Unknown annotation: {}".format(annotation))
-    else:
-        raise ValueError("Unknown annotation: {}".format(annotation))
+    raise ValueError("Unknown annotation: {}".format(annotation))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,9 +2,17 @@
 
 Beanie project
 
+## [1.22.2] - 2023-09-13
+        
+### Fix get_field_type & Generalize extract_id_class
+- Author - [George Sakkis](https://github.com/gsakkis)
+- PR <https://github.com/roman-right/beanie/pull/657>
+            
+[1.22.2]: https://pypi.org/project/beanie/1.22.2
+
 ## [1.22.1] - 2023-09-13
         
-### Fix | List_Collection_Names Requires Unnecessary Privileges
+### Fix | list_collection_names Requires Unnecessary Privileges
 - Author - [Marina](https://github.com/marinashe)
 - PR <https://github.com/roman-right/beanie/pull/681>
 - Issues:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "beanie"
-version = "1.22.1"
+version = "1.22.2"
 description = "Asynchronous Python ODM for MongoDB"
 readme = "README.md"
 requires-python = ">=3.7,<4.0"

--- a/tests/odm/test_typing_utils.py
+++ b/tests/odm/test_typing_utils.py
@@ -1,6 +1,11 @@
 from typing import Optional, Union
 
 from beanie.odm.utils.typing import extract_id_class
+from beanie import Document, Link
+
+
+class Lock(Document):
+    k: int
 
 
 class TestTyping:
@@ -11,3 +16,5 @@ class TestTyping:
         assert extract_id_class(Union[str, None, int]) == str
         # Optional
         assert extract_id_class(Optional[str]) == str
+        # Link
+        assert extract_id_class(Link[Lock]) == Lock

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.22.1"
+    assert __version__ == "1.22.2"


### PR DESCRIPTION
- Return `outer_type_` instead of `type_` from `get_field_type` for pydantic v1
- Generalize `extract_id_class` to support arbitrary generic types

The combination of these two changes allow using a custom generic type for id.