### PR TITLE
fix numpy array incompatability

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -31,7 +31,7 @@ from beanie.odm.documents import Document
 from beanie.odm.views import View
 from beanie.odm.union_doc import UnionDoc
 
-__version__ = "1.22.3"
+__version__ = "1.22.4"
 __all__ = [
     # ODM
     "Document",

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -154,12 +154,8 @@ class Encoder:
                 else:
                     obj_dict[k] = o
 
-                if hasattr(obj_dict[k], "all") or hasattr(obj_dict[k], "any"):
-                  is_ignore = False
-                else:
-                  is_ignore = obj_dict[k] == IGNORE
-
-                if is_ignore:
+                if isinstance(obj_dict[k], Ignore) and obj_dict[k] == IGNORE:
+                    # Check the class, as direct comparison might not work, like with numpy arrays
                     del obj_dict[k]
                 else:
                     obj_dict[k] = encoder.encode(obj_dict[k])

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -154,7 +154,12 @@ class Encoder:
                 else:
                     obj_dict[k] = o
 
-                if obj_dict[k] == IGNORE:
+                if hasattr(obj_dict[k], "all") or hasattr(obj_dict[k], "any"):
+                  is_ignore = False
+                else:
+                  is_ignore = obj_dict[k] == IGNORE
+
+                if is_ignore:
                     del obj_dict[k]
                 else:
                     obj_dict[k] = encoder.encode(obj_dict[k])

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,14 @@
 
 Beanie project
 
+## [1.22.4] - 2023-09-13
+        
+### Fix Numpy Array Incompatability
+- Author - [Alex Lau](https://github.com/riven314)
+- PR <https://github.com/roman-right/beanie/pull/658>
+            
+[1.22.4]: https://pypi.org/project/beanie/1.22.4
+
 ## [1.22.3] - 2023-09-13
         
 ### Refactor: Simplify UpdateMany And UpdateOne __await__ Method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "beanie"
-version = "1.22.3"
+version = "1.22.4"
 description = "Asynchronous Python ODM for MongoDB"
 readme = "README.md"
 requires-python = ">=3.7,<4.0"

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.22.3"
+    assert __version__ == "1.22.4"


### PR DESCRIPTION
**Problem:**
Current implementation raises error when a collection contains fields of type `np.ndarray`

**How to Reproduce:**
1. set up a mongodb server container in `docker-compose.yml`:
```
version: "3.8"
services:
  mongo:
    image: mongo:4.4.6
    restart: always
    environment:
      MONGO_INITDB_ROOT_USERNAME: root
      MONGO_INITDB_ROOT_PASSWORD: password
    ports:
      - 27017:27017
```
2. run the mongodb container: `docker-compose up -d`
3. prepare a script to insert a document with numpy array field on client side:
```
import asyncio
from io import BytesIO
from typing import Any, Callable, Iterator

import motor.motor_asyncio
import numpy as np
from beanie import Document, init_beanie
from bson import Binary
from bson.binary import USER_DEFINED_SUBTYPE


class ValidationError(Exception):
    pass


class NumpyField(np.ndarray):
    @classmethod
    def __get_validators__(cls) -> Iterator[Callable]:
        yield cls.validate

    @classmethod
    def validate(cls, value: Any) -> Any:
        if isinstance(value, Binary):
            try:
                np_stream = BytesIO(value)
                return np.load(np_stream)
            except Exception as e:
                raise ValidationError(
                    "Error in loading NumPy array from BSON: %s" % str(e)
                )
        return value

    @classmethod
    def __bson__(cls, value: np.ndarray) -> Binary:
        if isinstance(value, np.ndarray):
            try:
                np_stream = BytesIO()
                np.save(np_stream, value, allow_pickle=False)
                np_stream.seek(0)
                bin_data = np_stream.getbuffer().tobytes()
                return Binary(bin_data, USER_DEFINED_SUBTYPE)
            except Exception as e:
                raise ValidationError(
                    "Error in converting NumPy array to BSON: %s" % str(e)
                )
        raise ValidationError("Value must be a NumPy array")


def numpy_to_bson(value: np.ndarray) -> Binary:
    if isinstance(value, np.ndarray):
        try:
            np_stream = BytesIO()
            np.save(np_stream, value, allow_pickle=False)
            np_stream.seek(0)
            bin_data = np_stream.getbuffer().tobytes()
            return Binary(bin_data, USER_DEFINED_SUBTYPE)
        except Exception as e:
            raise ValidationError(
                "Error in converting NumPy array to BSON: %s" % str(e)
            )
    raise ValidationError("Value must be a NumPy array")


class User(Document):
    data: NumpyField

    class Settings:
        name = "users"
        bson_encoders = {np.ndarray: numpy_to_bson}


async def init_db_client():
    client = motor.motor_asyncio.AsyncIOMotorClient(
        "mongodb://root:password@localhost:27017"
    )
    database = client["test"]
    await init_beanie(database=database, document_models=[User])


async def main():
    await init_db_client()
    NP_DATA = np.random.random((10, 10))
    await User.insert_many([User(data=NP_DATA)])

asyncio.run(main())
```