### PR TITLE
fix | list_collection_names requires unnecessary privileges (#680)

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -31,7 +31,7 @@ from beanie.odm.documents import Document
 from beanie.odm.views import View
 from beanie.odm.union_doc import UnionDoc
 
-__version__ = "1.22.0"
+__version__ = "1.22.1"
 __all__ = [
     # ODM
     "Document",

--- a/beanie/odm/utils/init.py
+++ b/beanie/odm/utils/init.py
@@ -430,7 +430,7 @@ class Initializer:
         if (
             document_settings.timeseries is not None
             and document_settings.name
-            not in await self.database.list_collection_names()
+            not in await self.database.list_collection_names(authorizedCollections=True, nameOnly=True)
         ):
             collection = await self.database.create_collection(
                 **document_settings.timeseries.build_query(
@@ -642,7 +642,7 @@ class Initializer:
         self.init_view_fields(cls)
         self.init_cache(cls)
 
-        collection_names = await self.database.list_collection_names()
+        collection_names = await self.database.list_collection_names(authorizedCollections=True, nameOnly=True)
         if self.recreate_views or cls._settings.name not in collection_names:
             if cls._settings.name in collection_names:
                 await cls.get_motor_collection().drop()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,12 +2,21 @@
 
 Beanie project
 
+## [1.22.1] - 2023-09-13
+        
+### Fix | List_Collection_Names Requires Unnecessary Privileges
+- Author - [Marina](https://github.com/marinashe)
+- PR <https://github.com/roman-right/beanie/pull/681>
+- Issues:
+  - [[BUG] Can't use a View if the user doesn't have full read privileges to all collections](https://github.com/roman-right/beanie/issues/680)
+            
+[1.22.1]: https://pypi.org/project/beanie/1.22.1
+
 ## [1.22.0] - 2023-09-13
         
 ### Fix | August 2023
 - Author - [Roman Right](https://github.com/roman-right)
 - PR <https://github.com/roman-right/beanie/pull/669>
-            
 - Issues:
                     
   - [[BUG] Issue with `List[Link[Type]]` when `fetch_all_links` is called](https://github.com/roman-right/beanie/issues/576) 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "beanie"
-version = "1.22.0"
+version = "1.22.1"
 description = "Asynchronous Python ODM for MongoDB"
 readme = "README.md"
 requires-python = ">=3.7,<4.0"

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -2,4 +2,4 @@ from beanie import __version__
 
 
 def test_version():
-    assert __version__ == "1.22.0"
+    assert __version__ == "1.22.1"


### PR DESCRIPTION
This fixes the issue I encountered in #680.
The idea is to only list collections to which the user has access so that it will be possible to use a View with partially restricted users.