### PR TITLE
Preserve sort/skip/limit for aggregations

### DIFF
--- a/beanie/odm/utils/find.py
+++ b/beanie/odm/utils/find.py
@@ -1,8 +1,6 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Type
 
-from beanie.exceptions import NotSupported
 from beanie.odm.fields import LinkInfo, LinkTypes
-from beanie.odm.interfaces.detector import ModelType
 
 if TYPE_CHECKING:
     from beanie import Document
@@ -13,8 +11,6 @@ if TYPE_CHECKING:
 
 
 def construct_lookup_queries(cls: Type["Document"]) -> List[Dict[str, Any]]:
-    if cls.get_model_type() == ModelType.UnionDoc:
-        raise NotSupported("UnionDoc doesn't support link fetching")
     queries: List = []
     link_fields = cls.get_link_fields()
     if link_fields is not None:

--- a/tests/odm/query/test_aggregate.py
+++ b/tests/odm/query/test_aggregate.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import Field
 from pydantic.main import BaseModel
 
+from beanie.odm.enums import SortDirection
 from tests.odm.models import Sample
 
 
@@ -33,6 +34,36 @@ async def test_aggregate_with_filter(preset_documents):
     assert {"_id": "test_1", "total": 2} in result
     assert {"_id": "test_2", "total": 6} in result
     assert {"_id": "test_3", "total": 3} in result
+
+
+async def test_aggregate_with_sort_skip(preset_documents):
+    q = Sample.find(sort="_id", skip=2).aggregate(
+        [{"$group": {"_id": "$string", "total": {"$sum": "$integer"}}}]
+    )
+    assert q.get_aggregation_pipeline() == [
+        {"$group": {"_id": "$string", "total": {"$sum": "$integer"}}},
+        {"$sort": {"_id": SortDirection.ASCENDING}},
+        {"$skip": 2},
+    ]
+    assert await q.to_list() == [
+        {"_id": "test_2", "total": 6},
+        {"_id": "test_3", "total": 3},
+    ]
+
+
+async def test_aggregate_with_sort_limit(preset_documents):
+    q = Sample.find(sort="_id", limit=2).aggregate(
+        [{"$group": {"_id": "$string", "total": {"$sum": "$integer"}}}]
+    )
+    assert q.get_aggregation_pipeline() == [
+        {"$group": {"_id": "$string", "total": {"$sum": "$integer"}}},
+        {"$sort": {"_id": SortDirection.ASCENDING}},
+        {"$limit": 2},
+    ]
+    assert await q.to_list() == [
+        {"_id": "test_0", "total": 0},
+        {"_id": "test_1", "total": 3},
+    ]
 
 
 async def test_aggregate_with_projection_model(preset_documents):


### PR DESCRIPTION
Fix `FindMany.aggregate` to preseve any set sort/skip/limit stages.