### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: [ 3.7, 3.8, 3.9, 3.10.6, 3.11 ]
         mongodb-version: [ 4.4, 5.0 ]
-        pydantic-version: [ 1.10.11, 2.3 ]
+        pydantic-version: [ 1.10.12, 2.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
     - id: black
       language_version: python3.10
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.285
+    rev: v0.0.290
     hooks:
       - id: ruff
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:
     - id: black
@@ -16,4 +16,3 @@ repos:
           - types-click
           - types-toml
         exclude: ^tests/
-      


### PR DESCRIPTION
* https://github.com/psf/black updating 23.7.0 -> 23.9.1
* https://github.com/charliermarsh/ruff-pre-commit updating v0.0.285 -> v0.0.290
* https://github.com/pre-commit/mirrors-mypy already up to date