### PR TITLE
fix: reset operations after commit

### DIFF
--- a/beanie/odm/bulk.py
+++ b/beanie/odm/bulk.py
@@ -80,6 +80,8 @@ class BulkWriter:
             return await obj_class.get_motor_collection().bulk_write(  # type: ignore
                 requests, session=self.session
             )
+            self.operations = []
+
         return None
 
     def add_operation(self, operation: Operation):


### PR DESCRIPTION
### Context:

I found this issue when batching many requests to a bulk writer and manually committing 10'000 operations at a time (see pseudo code below)

```
async with BulkWriter() as bulk_writer:
    for counter, item in enumerate(items):
        # Do operations with bulk_writer
         
        if counter % 10000 == 0:
            bulk_writer.commit()
```


### What:

Reset the `operations` attribute after the operations have been committed in the bulk writer

### Why:

To ensure that after committing the list of operations is not done twice after a manual call of `commit()`


Please let me know if I missed something or I'm using the bulk writer in the wrong way but this very much looks like a bug. 