### PR TITLE
patch: update deprecated core_schema function

### DIFF
--- a/beanie/odm/custom_types/bson/binary.py
+++ b/beanie/odm/custom_types/bson/binary.py
@@ -31,7 +31,7 @@ class BsonBinary(bson.Binary):
                     "Value must be bytes or bson.Binary or BsonBinary"
                 )
 
-            python_schema = core_schema.general_plain_validator_function(validate)  # type: ignore
+            python_schema = core_schema.with_info_plain_validator_function(validate)  # type: ignore
 
             return core_schema.json_or_python_schema(
                 json_schema=core_schema.float_schema(),

--- a/beanie/odm/custom_types/decimal.py
+++ b/beanie/odm/custom_types/decimal.py
@@ -15,6 +15,8 @@ from pydantic.fields import FieldInfo
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema
 
+from beanie.odm.utils.pydantic import IS_PYDANTIC_V2
+
 
 class DecimalCustomAnnotation:
     @classmethod
@@ -28,7 +30,10 @@ class DecimalCustomAnnotation:
                 return value.to_decimal()
             return value
 
-        python_schema = core_schema.general_plain_validator_function(validate)  # type: ignore
+        if IS_PYDANTIC_V2:
+            python_schema = core_schema.with_info_plain_validator_function(validate)  # type: ignore
+        else:
+            python_schema = core_schema.general_plain_validator_function(validate)  # type: ignore
 
         return core_schema.json_or_python_schema(
             json_schema=core_schema.float_schema(),

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -120,7 +120,7 @@ class PydanticObjectId(ObjectId):
             cls, source_type: Any, handler: GetCoreSchemaHandler
         ) -> CoreSchema:  # type: ignore
             return core_schema.json_or_python_schema(
-                python_schema=core_schema.general_plain_validator_function(
+                python_schema=core_schema.with_info_plain_validator_function(
                     cls.validate
                 ),
                 json_schema=str_schema(),
@@ -357,7 +357,7 @@ class Link(Generic[T]):
             cls, source_type: Any, handler: GetCoreSchemaHandler
         ) -> CoreSchema:  # type: ignore
             return core_schema.json_or_python_schema(
-                python_schema=core_schema.general_plain_validator_function(
+                python_schema=core_schema.with_info_plain_validator_function(
                     cls.build_validation(handler, source_type)
                 ),
                 json_schema=core_schema.typed_dict_schema(
@@ -373,9 +373,6 @@ class Link(Generic[T]):
                 serialization=core_schema.plain_serializer_function_ser_schema(  # type: ignore
                     lambda instance: cls.serialize(instance)  # type: ignore
                 ),
-            )
-            return core_schema.general_plain_validator_function(
-                cls.build_validation(handler, source_type)
             )
 
     else:
@@ -434,7 +431,7 @@ class BackLink(Generic[T]):
         def __get_pydantic_core_schema__(
             cls, source_type: Any, handler: GetCoreSchemaHandler
         ) -> CoreSchema:  # type: ignore
-            return core_schema.general_plain_validator_function(
+            return core_schema.with_info_plain_validator_function(
                 cls.build_validation(handler, source_type)
             )
 
@@ -541,7 +538,7 @@ class IndexModelField:
                 else:
                     return IndexModelField(IndexModel(v))
 
-            return core_schema.general_plain_validator_function(validate)
+            return core_schema.with_info_plain_validator_function(validate)
 
     else:
 

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -91,7 +91,14 @@ class Color:
                 return Color(value["value"])
             return Color(value)
 
-        python_schema = core_schema.general_plain_validator_function(validate)
+        if IS_PYDANTIC_V2:
+            python_schema = core_schema.with_info_plain_validator_function(
+                validate
+            )
+        else:
+            python_schema = core_schema.general_plain_validator_function(
+                validate
+            )
 
         return core_schema.json_or_python_schema(
             json_schema=core_schema.str_schema(),


### PR DESCRIPTION
## Purpose
This PR fixes some deprecation warnings while using Pydantic v2. 

## Context
There were deprecation warnings while running pytest in my PydanticV2 `(2.4.1)` project.
```sh
====================================== warnings summary ======================================
venv/lib/python3.10/site-packages/beanie/odm/fields.py:544
  venv/lib/python3.10/site-packages/beanie/odm/fields.py:544: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    return core_schema.general_plain_validator_function(validate)

venv/lib/python3.10/site-packages/pydantic_core/core_schema.py:3898
venv/lib/python3.10/site-packages/pydantic_core/core_schema.py:3898
venv/lib/python3.10/site-packages/pydantic_core/core_schema.py:3898
venv/lib/python3.10/site-packages/pydantic_core/core_schema.py:3898
venv/lib/python3.10/site-packages/pydantic_core/core_schema.py:3898
venv/lib/python3.10/site-packages/pydantic_core/core_schema.py:3898
  venv/lib/python3.10/site-packages/pydantic_core/core_schema.py:3898: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    warnings.warn(

venv/lib/python3.10/site-packages/beanie/odm/fields.py:123
venv/lib/python3.10/site-packages/beanie/odm/fields.py:123
venv/lib/python3.10/site-packages/beanie/odm/fields.py:123
venv/lib/python3.10/site-packages/beanie/odm/fields.py:123
venv/lib/python3.10/site-packages/beanie/odm/fields.py:123
  venv/lib/python3.10/site-packages/beanie/odm/fields.py:123: DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    python_schema=core_schema.general_plain_validator_function(

```

