### PR TITLE
Add support for custom bucket fields in time series

### DIFF
--- a/beanie/odm/settings/timeseries.py
+++ b/beanie/odm/settings/timeseries.py
@@ -28,7 +28,7 @@ class TimeSeriesConfig(BaseModel):
 
     def build_query(self, collection_name: str) -> Dict[str, Any]:
         res: Dict[str, Any] = {"name": collection_name}
-        timeseries = {"timeField": self.time_field}
+        timeseries: Dict[str, Any] = {"timeField": self.time_field}
         if self.meta_field is not None:
             timeseries["metaField"] = self.meta_field
         if self.granularity is not None:

--- a/beanie/odm/settings/timeseries.py
+++ b/beanie/odm/settings/timeseries.py
@@ -22,7 +22,9 @@ class TimeSeriesConfig(BaseModel):
     time_field: str
     meta_field: Optional[str] = None
     granularity: Optional[Granularity] = None
-    expire_after_seconds: Optional[float] = None
+    bucket_max_span_seconds: Optional[int] = None
+    bucket_rounding_second: Optional[int] = None
+    expire_after_seconds: Optional[int] = None
 
     def build_query(self, collection_name: str) -> Dict[str, Any]:
         res: Dict[str, Any] = {"name": collection_name}
@@ -31,6 +33,10 @@ class TimeSeriesConfig(BaseModel):
             timeseries["metaField"] = self.meta_field
         if self.granularity is not None:
             timeseries["granularity"] = self.granularity
+        if self.bucket_max_span_seconds is not None:
+            timeseries["bucketMaxSpanSeconds"] = self.bucket_max_span_seconds
+        if self.bucket_rounding_second is not None:
+            timeseries["bucketRoundingSeconds"] = self.bucket_rounding_second
         res["timeseries"] = timeseries
         if self.expire_after_seconds is not None:
             res["expireAfterSeconds"] = self.expire_after_seconds

--- a/docs/tutorial/time_series.md
+++ b/docs/tutorial/time_series.md
@@ -2,7 +2,7 @@
 
 You can set up a timeseries collection using the inner `Settings` class.
 
-**Be aware, timeseries collections a supported by MongoDB 5.0 and higher only.**
+**Be aware, timeseries collections a supported by MongoDB 5.0 and higher only. The fields `bucket_max_span_seconds` and `bucket_rounding_seconds` however require MongoDB 6.3 or higher**
 
 ```python
 from datetime import datetime
@@ -20,6 +20,8 @@ class Sample(Document):
             time_field="ts", #  Required
             meta_field="meta", #  Optional
             granularity=Granularity.hours, #  Optional
+            bucket_max_span_seconds=3600,  #  Optional
+            bucket_rounding_seconds=3600,  #  Optional
             expire_after_seconds=2  #  Optional
         )
 ```


### PR DESCRIPTION
This PR adds support for the custom bucket fields for time series introduced in MongoDB 6.3 https://www.mongodb.com/docs/manual/core/timeseries/timeseries-procedures/