### PR TITLE
Add BSON MaxKey and MinKey

### DIFF
--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -58,6 +58,8 @@ BSON_SCALAR_TYPES = (
     bson.Binary,
     bson.DBRef,
     bson.Decimal128,
+    bson.MaxKey,
+    bson.MinKey,
     bson.ObjectId,
 )
 


### PR DESCRIPTION
MaxKey and Minkey are BSON types that are primarily used in queries. This merge request updates Beanie to pass through those types correctly.

https://www.mongodb.com/docs/manual/reference/bson-types/