### PR TITLE
Fix encoding keys in `Mapping` branch of `Encoder`

### DIFF
--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -128,7 +128,7 @@ class Encoder:
             items = self._iter_model_items(obj)
             return {key: self.encode(value) for key, value in items}
         if isinstance(obj, Mapping):
-            return {key: self.encode(value) for key, value in obj.items()}
+            return {self.encode(key): self.encode(value) for key, value in obj.items()}
         if isinstance(obj, Iterable):
             return [self.encode(value) for value in obj]
 

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -128,7 +128,7 @@ class Encoder:
             items = self._iter_model_items(obj)
             return {key: self.encode(value) for key, value in items}
         if isinstance(obj, Mapping):
-            return {self.encode(key): self.encode(value) for key, value in obj.items()}
+            return {str(key): self.encode(value) for key, value in obj.items()}
         if isinstance(obj, Iterable):
             return [self.encode(value) for value in obj]
 

--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -34,6 +34,7 @@ from tests.odm.models import (
     DocumentWithBackLink,
     DocumentWithBsonBinaryField,
     DocumentWithBsonEncodersFiledsTypes,
+    DocumentWithComplexDictKey,
     DocumentWithCustomFiledsTypes,
     DocumentWithCustomIdInt,
     DocumentWithCustomIdUUID,
@@ -277,6 +278,7 @@ async def init(db):
         DocWithCallWrapper,
         DocumentWithOptionalBackLink,
         DocumentWithOptionalListBackLink,
+        DocumentWithComplexDictKey,
     ]
     await init_beanie(
         database=db,

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -1048,3 +1048,6 @@ class DocWithCallWrapper(Document):
 
 class DocumentWithHttpUrlField(Document):
     url_field: HttpUrl
+
+class DocumentWithComplexDictKey(Document):
+    dict_field: Dict[UUID, datetime.datetime]

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -1049,5 +1049,6 @@ class DocWithCallWrapper(Document):
 class DocumentWithHttpUrlField(Document):
     url_field: HttpUrl
 
+
 class DocumentWithComplexDictKey(Document):
     dict_field: Dict[UUID, datetime.datetime]

--- a/tests/odm/test_encoder.py
+++ b/tests/odm/test_encoder.py
@@ -1,5 +1,6 @@
 import re
 from datetime import date, datetime
+from uuid import uuid4
 
 import pytest
 from bson import Binary, Regex
@@ -11,6 +12,7 @@ from tests.odm.models import (
     Child,
     DocumentForEncodingTest,
     DocumentForEncodingTestDate,
+    DocumentWithComplexDictKey,
     DocumentWithDecimalField,
     DocumentWithHttpUrlField,
     DocumentWithKeepNullsFalse,
@@ -152,3 +154,18 @@ async def test_should_be_able_to_save_retrieve_doc_with_url():
 
     assert isinstance(new_doc.url_field, AnyUrl)
     assert new_doc.url_field == doc.url_field
+
+
+async def test_dict_with_complex_key():
+    assert isinstance(Encoder().encode({uuid4(): datetime.now()}), dict)
+
+    uuid = uuid4()
+    # reset microseconds, because it looses by mongo
+    dt = datetime.now().replace(microsecond=0)  
+
+    doc = DocumentWithComplexDictKey(dict_field={uuid: dt})
+    await doc.insert()
+    new_doc = await DocumentWithComplexDictKey.get(doc.id)
+
+    assert isinstance(new_doc.dict_field, dict)
+    assert new_doc.dict_field.get(uuid) == dt

--- a/tests/odm/test_encoder.py
+++ b/tests/odm/test_encoder.py
@@ -161,7 +161,7 @@ async def test_dict_with_complex_key():
 
     uuid = uuid4()
     # reset microseconds, because it looses by mongo
-    dt = datetime.now().replace(microsecond=0)  
+    dt = datetime.now().replace(microsecond=0)
 
     doc = DocumentWithComplexDictKey(dict_field={uuid: dt})
     await doc.insert()


### PR DESCRIPTION
Force every `Mapping` (dict, etc...) keys be string after encoding, because in other way mongo will throw
`bson.errors.InvalidDocument: documents must have only string keys, key was <key>`.

This needs for normal encoding dicts like `dict[uuid.UUID, datetime.datetime]`.