### PR TITLE
Fix: FindInterface type-hints break on View models

### DIFF
--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -130,7 +130,7 @@ class Document(
     LazyModel,
     SettersInterface,
     InheritanceInterface,
-    FindInterface,
+    FindInterface[DocType],
     AggregateInterface,
     OtherGettersInterface,
 ):

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -130,7 +130,7 @@ class Document(
     LazyModel,
     SettersInterface,
     InheritanceInterface,
-    FindInterface[DocType],
+    FindInterface,
     AggregateInterface,
     OtherGettersInterface,
 ):
@@ -1012,7 +1012,8 @@ class Document(
             return {}
 
         return self._collect_updates(
-            self._previous_saved_state, self._saved_state  # type: ignore
+            self._previous_saved_state,
+            self._saved_state,  # type: ignore
         )
 
     @saved_state_needed

--- a/beanie/odm/interfaces/find.py
+++ b/beanie/odm/interfaces/find.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable
 from typing import (
     TYPE_CHECKING,
     Any,
-    Generic,
     ClassVar,
     Dict,
     List,
@@ -27,13 +26,14 @@ from beanie.odm.queries.find import FindMany, FindOne
 from beanie.odm.settings.base import ItemSettings
 
 if TYPE_CHECKING:
-    from beanie.odm.documents import DocType
-    from beanie.odm.views import ViewType
+    from beanie.odm.documents import Document
+    from beanie.odm.views import View
 
 DocumentProjectionType = TypeVar("DocumentProjectionType", bound=BaseModel)
-FindType = TypeVar("FindType", bound=Union["DocType", "ViewType"])
+FindType = TypeVar("FindType", bound=Union["Document", "View"])
 
-class FindInterface(Generic[FindType]):
+
+class FindInterface:
     # Customization
     # Query builders could be replaced in the inherited classes
     _find_one_query_class: ClassVar[Type] = FindOne

--- a/beanie/odm/interfaces/find.py
+++ b/beanie/odm/interfaces/find.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 from typing import (
     TYPE_CHECKING,
     Any,
+    Generic,
     ClassVar,
     Dict,
     List,
@@ -27,11 +28,12 @@ from beanie.odm.settings.base import ItemSettings
 
 if TYPE_CHECKING:
     from beanie.odm.documents import DocType
+    from beanie.odm.views import ViewType
 
 DocumentProjectionType = TypeVar("DocumentProjectionType", bound=BaseModel)
+FindType = TypeVar("FindType", bound=Union["DocType", "ViewType"])
 
-
-class FindInterface:
+class FindInterface(Generic[FindType]):
     # Customization
     # Query builders could be replaced in the inherited classes
     _find_one_query_class: ClassVar[Type] = FindOne
@@ -54,7 +56,7 @@ class FindInterface:
     @overload
     @classmethod
     def find_one(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         *args: Union[Mapping[str, Any], bool],
         projection_model: None = None,
         session: Optional[ClientSession] = None,
@@ -62,13 +64,13 @@ class FindInterface:
         fetch_links: bool = False,
         with_children: bool = False,
         **pymongo_kwargs,
-    ) -> FindOne["DocType"]:
+    ) -> FindOne[FindType]:
         ...
 
     @overload
     @classmethod
     def find_one(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         *args: Union[Mapping[str, Any], bool],
         projection_model: Type["DocumentProjectionType"],
         session: Optional[ClientSession] = None,
@@ -81,7 +83,7 @@ class FindInterface:
 
     @classmethod
     def find_one(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         *args: Union[Mapping[str, Any], bool],
         projection_model: Optional[Type["DocumentProjectionType"]] = None,
         session: Optional[ClientSession] = None,
@@ -89,7 +91,7 @@ class FindInterface:
         fetch_links: bool = False,
         with_children: bool = False,
         **pymongo_kwargs,
-    ) -> Union[FindOne["DocType"], FindOne["DocumentProjectionType"]]:
+    ) -> Union[FindOne[FindType], FindOne["DocumentProjectionType"]]:
         """
         Find one document by criteria.
         Returns [FindOne](query.md#findone) query object.
@@ -115,7 +117,7 @@ class FindInterface:
     @overload
     @classmethod
     def find_many(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         *args: Union[Mapping[str, Any], bool],
         projection_model: None = None,
         skip: Optional[int] = None,
@@ -127,13 +129,13 @@ class FindInterface:
         with_children: bool = False,
         lazy_parse: bool = False,
         **pymongo_kwargs,
-    ) -> FindMany["DocType"]:
+    ) -> FindMany[FindType]:
         ...
 
     @overload
     @classmethod
     def find_many(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         *args: Union[Mapping[str, Any], bool],
         projection_model: Optional[Type["DocumentProjectionType"]] = None,
         skip: Optional[int] = None,
@@ -150,7 +152,7 @@ class FindInterface:
 
     @classmethod
     def find_many(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         *args: Union[Mapping[str, Any], bool],
         projection_model: Optional[Type["DocumentProjectionType"]] = None,
         skip: Optional[int] = None,
@@ -162,7 +164,7 @@ class FindInterface:
         with_children: bool = False,
         lazy_parse: bool = False,
         **pymongo_kwargs,
-    ) -> Union[FindMany["DocType"], FindMany["DocumentProjectionType"]]:
+    ) -> Union[FindMany[FindType], FindMany["DocumentProjectionType"]]:
         """
         Find many documents by criteria.
         Returns [FindMany](query.md#findmany) query object
@@ -195,7 +197,7 @@ class FindInterface:
     @overload
     @classmethod
     def find(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         *args: Union[Mapping[str, Any], bool],
         projection_model: None = None,
         skip: Optional[int] = None,
@@ -207,13 +209,13 @@ class FindInterface:
         with_children: bool = False,
         lazy_parse: bool = False,
         **pymongo_kwargs,
-    ) -> FindMany["DocType"]:
+    ) -> FindMany[FindType]:
         ...
 
     @overload
     @classmethod
     def find(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         *args: Union[Mapping[str, Any], bool],
         projection_model: Type["DocumentProjectionType"],
         skip: Optional[int] = None,
@@ -230,7 +232,7 @@ class FindInterface:
 
     @classmethod
     def find(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         *args: Union[Mapping[str, Any], bool],
         projection_model: Optional[Type["DocumentProjectionType"]] = None,
         skip: Optional[int] = None,
@@ -242,7 +244,7 @@ class FindInterface:
         with_children: bool = False,
         lazy_parse: bool = False,
         **pymongo_kwargs,
-    ) -> Union[FindMany["DocType"], FindMany["DocumentProjectionType"]]:
+    ) -> Union[FindMany[FindType], FindMany["DocumentProjectionType"]]:
         """
         The same as find_many
         """
@@ -263,7 +265,7 @@ class FindInterface:
     @overload
     @classmethod
     def find_all(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         skip: Optional[int] = None,
         limit: Optional[int] = None,
         sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
@@ -273,13 +275,13 @@ class FindInterface:
         with_children: bool = False,
         lazy_parse: bool = False,
         **pymongo_kwargs,
-    ) -> FindMany["DocType"]:
+    ) -> FindMany[FindType]:
         ...
 
     @overload
     @classmethod
     def find_all(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         skip: Optional[int] = None,
         limit: Optional[int] = None,
         sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
@@ -294,7 +296,7 @@ class FindInterface:
 
     @classmethod
     def find_all(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         skip: Optional[int] = None,
         limit: Optional[int] = None,
         sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
@@ -304,7 +306,7 @@ class FindInterface:
         with_children: bool = False,
         lazy_parse: bool = False,
         **pymongo_kwargs,
-    ) -> Union[FindMany["DocType"], FindMany["DocumentProjectionType"]]:
+    ) -> Union[FindMany[FindType], FindMany["DocumentProjectionType"]]:
         """
         Get all the documents
 
@@ -332,7 +334,7 @@ class FindInterface:
     @overload
     @classmethod
     def all(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         projection_model: None = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
@@ -342,13 +344,13 @@ class FindInterface:
         with_children: bool = False,
         lazy_parse: bool = False,
         **pymongo_kwargs,
-    ) -> FindMany["DocType"]:
+    ) -> FindMany[FindType]:
         ...
 
     @overload
     @classmethod
     def all(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         projection_model: Type["DocumentProjectionType"],
         skip: Optional[int] = None,
         limit: Optional[int] = None,
@@ -363,7 +365,7 @@ class FindInterface:
 
     @classmethod
     def all(  # type: ignore
-        cls: Type["DocType"],
+        cls: Type[FindType],
         projection_model: Optional[Type["DocumentProjectionType"]] = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
@@ -373,7 +375,7 @@ class FindInterface:
         with_children: bool = False,
         lazy_parse: bool = False,
         **pymongo_kwargs,
-    ) -> Union[FindMany["DocType"], FindMany["DocumentProjectionType"]]:
+    ) -> Union[FindMany[FindType], FindMany["DocumentProjectionType"]]:
         """
         the same as find_all
         """

--- a/beanie/odm/views.py
+++ b/beanie/odm/views.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, ClassVar, Dict, Optional, Union
+from typing import Any, ClassVar, Dict, Optional, Union, TypeVar
 
 from pydantic import BaseModel
 
@@ -11,10 +11,11 @@ from beanie.odm.interfaces.find import FindInterface
 from beanie.odm.interfaces.getters import OtherGettersInterface
 from beanie.odm.settings.view import ViewSettings
 
+ViewType = TypeVar("ViewType", bound="View")
 
 class View(
     BaseModel,
-    FindInterface,
+    FindInterface[ViewType],
     AggregateInterface,
     OtherGettersInterface,
     DetectionInterface,

--- a/beanie/odm/views.py
+++ b/beanie/odm/views.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, ClassVar, Dict, Optional, Union, TypeVar
+from typing import Any, ClassVar, Dict, Optional, Union
 
 from pydantic import BaseModel
 
@@ -11,11 +11,10 @@ from beanie.odm.interfaces.find import FindInterface
 from beanie.odm.interfaces.getters import OtherGettersInterface
 from beanie.odm.settings.view import ViewSettings
 
-ViewType = TypeVar("ViewType", bound="View")
 
 class View(
     BaseModel,
-    FindInterface[ViewType],
+    FindInterface,
     AggregateInterface,
     OtherGettersInterface,
     DetectionInterface,


### PR DESCRIPTION
This PR adds a new TypeVar for `View` just like `DocType`, and is used in `FindInterface` to bind it for each model with their respective model type.

It fixes a bug where find operations type-checks break when used with `View` descendants. For example, see [this issue](https://github.com/roman-right/beanie/issues/684).


