### PR TITLE
fix: count with text queries and links

### DIFF
--- a/beanie/odm/queries/find.py
+++ b/beanie/odm/queries/find.py
@@ -689,14 +689,7 @@ class FindMany(
         if self.fetch_links:
             aggregation_pipeline: List[
                 Dict[str, Any]
-            ] = construct_lookup_queries(self.document_model)
-
-            aggregation_pipeline.append({"$match": self.get_filter_query()})
-
-            if self.skip_number != 0:
-                aggregation_pipeline.append({"$skip": self.skip_number})
-            if self.limit_number != 0:
-                aggregation_pipeline.append({"$limit": self.limit_number})
+            ] = self.build_aggregation_pipeline()
 
             aggregation_pipeline.append({"$count": "count"})
 


### PR DESCRIPTION
This PR aims to fix the `count` method when combining links and text queries.

Currently, the `count` method has the same issue as described in #606. This PR aims to implement the fix in #752 for the `count` method. 