### PR TITLE
Update migration command to enable/disable transactions

### DIFF
--- a/beanie/executors/migrate.py
+++ b/beanie/executors/migrate.py
@@ -53,6 +53,7 @@ class MigrationSettings:
             or self.get_from_toml("allow_index_dropping")
             or False
         )
+        self.use_transaction = bool(kwargs.get("use_transaction"))
 
     @staticmethod
     def get_env_value(field_name) -> Any:
@@ -111,7 +112,9 @@ async def run_migrate(settings: MigrationSettings):
         direction=settings.direction, distance=settings.distance
     )
     await root.run(
-        mode=mode, allow_index_dropping=settings.allow_index_dropping
+        mode=mode,
+        allow_index_dropping=settings.allow_index_dropping,
+        use_transaction=settings.use_transaction,
     )
 
 
@@ -160,6 +163,15 @@ async def run_migrate(settings: MigrationSettings):
     default=False,
     help="if allow-index-dropping is set, Beanie will drop indexes from your collection",
 )
+@click.option(
+    "--use-transaction/--no-use-transaction",
+    required=False,
+    default=True,
+    help="Enable or disable the use of transactions during migration. "
+    "When enabled (--use-transaction), Beanie uses transactions for migration, "
+    "which necessitates a replica set. When disabled (--no-use-transaction), "
+    "migrations occur without transactions.",
+)
 def migrate(
     direction,
     distance,
@@ -167,6 +179,7 @@ def migrate(
     database_name,
     path,
     allow_index_dropping,
+    use_transaction,
 ):
     settings_kwargs = {}
     if direction:
@@ -181,6 +194,7 @@ def migrate(
         settings_kwargs["path"] = path
     if allow_index_dropping:
         settings_kwargs["allow_index_dropping"] = allow_index_dropping
+    settings_kwargs["use_transaction"] = use_transaction
     settings = MigrationSettings(**settings_kwargs)
 
     asyncio.run(run_migrate(settings))

--- a/beanie/migrations/controllers/base.py
+++ b/beanie/migrations/controllers/base.py
@@ -5,6 +5,9 @@ from beanie.odm.documents import Document
 
 
 class BaseMigrationController(ABC):
+    def __init__(self, function):
+        self.function = function
+
     @abstractmethod
     async def run(self, session):
         pass

--- a/docs/tutorial/migrations.md
+++ b/docs/tutorial/migrations.md
@@ -1,6 +1,5 @@
 ## Attention!
 
-Migrations use transactions inside. They work only with **MongoDB replica sets**
 
 ## Create
 
@@ -17,6 +16,8 @@ Each one contains instructions to roll migration respectively forward and backwa
 
 ## Run
 
+**Attention**: By default, migrations use transactions. This approach only works with  **MongoDB replica sets**. If you prefer to run migrations without transactions, pass the `--no-use-transaction` flag to the `migrate` command. However, be aware that this approach is risky, as there is no way to roll back migrations without transactions.
+
 To roll one forward migration, run:
 
 ```shell
@@ -26,7 +27,7 @@ beanie migrate -uri 'mongodb+srv://user:pass@host/db' -p relative/path/to/migrat
 To roll all forward migrations, run:
 
 ```shell
-beanie migrate -uri 'mongodb+srv://user:pass@host/db' -p relative/path/to/migrations/directory/
+beanie migrate -uri 'mongodb://user:pass@host' -db db -p relative/path/to/migrations/directory/
 ```
 
 To roll one backward migration, run:

--- a/tests/migrations/test_free_fall.py
+++ b/tests/migrations/test_free_fall.py
@@ -65,3 +65,26 @@ async def test_migration_free_fall(settings, notes, db):
     assert inspection.status == InspectionStatuses.OK
     note = await OldNote.find_one({})
     assert note.name == "0"
+
+
+async def test_migration_free_fall_no_use_transactions(settings, notes, db):
+    migration_settings = MigrationSettings(
+        connection_uri=settings.mongodb_dsn,
+        database_name=settings.mongodb_db_name,
+        path="tests/migrations/migrations_for_test/free_fall",
+        use_transaction=False,
+    )
+    await run_migrate(migration_settings)
+
+    await init_beanie(database=db, document_models=[Note])
+    inspection = await Note.inspect_collection()
+    assert inspection.status == InspectionStatuses.OK
+    note = await Note.find_one({})
+    assert note.title == "0"
+
+    migration_settings.direction = RunningDirections.BACKWARD
+    await run_migrate(migration_settings)
+    inspection = await OldNote.inspect_collection()
+    assert inspection.status == InspectionStatuses.OK
+    note = await OldNote.find_one({})
+    assert note.name == "0"


### PR DESCRIPTION
This is a modified version of Beanie that includes an option to enable or disable transactions during migrations. Please see the motivation here (https://github.com/roman-right/beanie/discussions/827). To run a migration without a transaction, use the following command:

```shell
beanie migrate --no-use-transaction -uri 'mongodb://username:password@localhost' -db 'db' -p .
```

Please let me know if you'd like this feature in the upstream, and whether you require any changes to the PR. I will ensure to squash the commits and tidy things up.