### PR TITLE
Sync Method

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -16,7 +16,7 @@ from beanie.odm.actions import (
 from beanie.odm.bulk import BulkWriter
 from beanie.odm.custom_types import DecimalAnnotation
 from beanie.odm.custom_types.bson.binary import BsonBinary
-from beanie.odm.documents import Document
+from beanie.odm.documents import Document, MergeStrategy
 from beanie.odm.enums import SortDirection
 from beanie.odm.fields import (
     BackLink,
@@ -46,6 +46,7 @@ __all__ = [
     "TimeSeriesConfig",
     "Granularity",
     "SortDirection",
+    "MergeStrategy",
     # Actions
     "before_event",
     "after_event",

--- a/beanie/exceptions.py
+++ b/beanie/exceptions.py
@@ -68,3 +68,7 @@ class DocWasNotRegisteredInUnionClass(Exception):
 
 class Deprecation(Exception):
     pass
+
+
+class ApplyChangesException(Exception):
+    pass

--- a/beanie/odm/utils/parsing.py
+++ b/beanie/odm/utils/parsing.py
@@ -1,8 +1,9 @@
-from typing import TYPE_CHECKING, Any, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Type, Union
 
 from pydantic import BaseModel
 
 from beanie.exceptions import (
+    ApplyChangesException,
     DocWasNotRegisteredInUnionClass,
     UnionHasNoRegisteredDocs,
 )
@@ -43,6 +44,47 @@ def merge_models(left: BaseModel, right: BaseModel) -> None:
             left.__setattr__(k, right_value)
         elif not isinstance(right_value, Link):
             left.__setattr__(k, right_value)
+
+
+def apply_changes(
+    changes: Dict[str, Any], target: Union[BaseModel, Dict[str, Any]]
+):
+    for key, value in changes.items():
+        if "." in key:
+            key_parts = key.split(".")
+            current_target = target
+            try:
+                for part in key_parts[:-1]:
+                    if isinstance(current_target, dict):
+                        current_target = current_target[part]
+                    elif isinstance(current_target, BaseModel):
+                        current_target = getattr(current_target, part)
+                    else:
+                        raise ApplyChangesException(
+                            f"Unexpected type of target: {type(target)}"
+                        )
+                final_key = key_parts[-1]
+                if isinstance(current_target, dict):
+                    current_target[final_key] = value
+                elif isinstance(current_target, BaseModel):
+                    setattr(current_target, final_key, value)
+                else:
+                    raise ApplyChangesException(
+                        f"Unexpected type of target: {type(target)}"
+                    )
+            except (KeyError, AttributeError) as e:
+                raise ApplyChangesException(
+                    f"Failed to apply change for key '{key}': {e}"
+                )
+        else:
+            if isinstance(target, dict):
+                target[key] = value
+            elif isinstance(target, BaseModel):
+                setattr(target, key, value)
+            else:
+                raise ApplyChangesException(
+                    f"Unexpected type of target: {type(target)}"
+                )
 
 
 def save_state(item: BaseModel):

--- a/docs/tutorial/find.md
+++ b/docs/tutorial/find.md
@@ -77,6 +77,38 @@ you can use the [find_one](../api-documentation/interfaces.md/#findinterfacefind
 bar = await Product.find_one(Product.name == "Peanut Bar")
 ```
 
+## Syncing from the Database
+
+If you wish to apply changes from the database to the document, utilize the [sync](../api-documentation/document.md/#documentsync) method:
+
+```python
+await bar.sync()
+```
+
+Two merging strategies are available: `local` and `remote`.
+
+### Remote Merge Strategy
+
+The remote merge strategy replaces the local document with the one from the database, disregarding local changes:
+
+```python
+from beanie import MergeStrategy
+
+await bar.sync(merge_strategy=MergeStrategy.remote)
+```
+The remote merge strategy is the default.
+
+### Local Merge Strategy
+
+The local merge strategy retains changes made locally to the document and updates other fields from the database.
+**BE CAREFUL**: it may raise an `ApplyChangesException` in case of a merging conflict.
+
+```python
+from beanie import MergeStrategy
+
+await bar.sync(merge_strategy=MergeStrategy.local)
+```
+
 ## More complex queries
 
 ### Multiple search criteria

--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -28,6 +28,7 @@ from tests.odm.models import (
     DocumentTestModelWithLink,
     DocumentTestModelWithSimpleIndex,
     DocumentToBeLinked,
+    DocumentToTestSync,
     DocumentUnion,
     DocumentWithActions,
     DocumentWithActions2,
@@ -281,6 +282,7 @@ async def init(db):
         DocumentWithOptionalListBackLink,
         DocumentWithComplexDictKey,
         DocumentWithIndexedObjectId,
+        DocumentToTestSync,
     ]
     await init_beanie(
         database=db,

--- a/tests/odm/documents/test_sync.py
+++ b/tests/odm/documents/test_sync.py
@@ -1,0 +1,54 @@
+import pytest
+
+from beanie.exceptions import ApplyChangesException
+from beanie.odm.documents import MergeStrategy
+from tests.odm.models import DocumentToTestSync
+
+
+class TestSync:
+    async def test_merge_remote(self):
+        doc = DocumentToTestSync()
+        await doc.insert()
+
+        doc2 = await DocumentToTestSync.get(doc.id)
+        doc2.s = "foo"
+
+        doc.i = 100
+        await doc.save()
+
+        await doc2.sync()
+
+        assert doc2.s == "TEST"
+        assert doc2.i == 100
+
+    async def test_merge_local(self):
+        doc = DocumentToTestSync(d={"option_1": {"s": "foo"}})
+        await doc.insert()
+
+        doc2 = await DocumentToTestSync.get(doc.id)
+        doc2.s = "foo"
+        doc2.n.option_1.s = "bar"
+        doc2.d["option_1"]["s"] = "bar"
+
+        doc.i = 100
+        await doc.save()
+
+        await doc2.sync(merge_strategy=MergeStrategy.local)
+
+        assert doc2.s == "foo"
+        assert doc2.n.option_1.s == "bar"
+        assert doc2.d["option_1"]["s"] == "bar"
+
+        assert doc2.i == 100
+
+    async def test_merge_local_impossible_apply_changes(self):
+        doc = DocumentToTestSync(d={"option_1": {"s": "foo"}})
+        await doc.insert()
+
+        doc2 = await DocumentToTestSync.get(doc.id)
+        doc2.d["option_1"]["s"] = {"foo": "bar"}
+
+        doc.d = {"option_1": "nothing"}
+        await doc.save()
+        with pytest.raises(ApplyChangesException):
+            await doc2.sync(merge_strategy=MergeStrategy.local)

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -1060,3 +1060,16 @@ class DocumentWithIndexedObjectId(Document):
     pyid: Indexed(PydanticObjectId)
     uuid: Annotated[UUID4, Indexed(unique=True)]
     email: Annotated[EmailStr, Indexed(unique=True)]
+
+
+class DocumentToTestSync(Document):
+    s: str = "TEST"
+    i: int = 1
+    n: Nested = Nested(
+        integer=1, option_1=Option1(s="test"), union=Option1(s="test")
+    )
+    o: Optional[Option2] = None
+    d: Dict[str, Any] = {}
+
+    class Settings:
+        use_state_management = True


### PR DESCRIPTION
## Syncing from the Database

If you wish to apply changes from the database to the document, utilize the [sync](../api-documentation/document.md/#documentsync) method:

```python
await bar.sync()
```

Two merging strategies are available: `local` and `remote`.

### Remote Merge Strategy

The remote merge strategy replaces the local document with the one from the database, disregarding local changes:

```python
from beanie import MergeStrategy

await bar.sync(merge_strategy=MergeStrategy.remote)
```
The remote merge strategy is the default.

### Local Merge Strategy

The local merge strategy retains changes made locally to the document and updates other fields from the database.
**BE CAREFUL**: it may raise an `ApplyChangesException` in case of a merging conflict.

```python
from beanie import MergeStrategy

await bar.sync(merge_strategy=MergeStrategy.local)
```