### PR TITLE
add pipeline support for query update methods

### DIFF
--- a/beanie/odm/interfaces/update.py
+++ b/beanie/odm/interfaces/update.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from pymongo.client_session import ClientSession
 
@@ -20,7 +20,7 @@ class UpdateMethods:
     @abstractmethod
     def update(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         **kwargs,

--- a/beanie/odm/queries/find.py
+++ b/beanie/odm/queries/find.py
@@ -428,7 +428,7 @@ class FindMany(
 
     def update(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         **pymongo_kwargs,
@@ -437,7 +437,7 @@ class FindMany(
         Create Update with modifications query
         and provide search criteria there
 
-        :param args: *Mapping[str,Any] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param session: Optional[ClientSession]
         :param bulk_writer: Optional[BulkWriter]
         :return: UpdateMany query
@@ -454,7 +454,7 @@ class FindMany(
 
     def upsert(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         on_insert: "DocType",
         session: Optional[ClientSession] = None,
         **pymongo_kwargs,
@@ -463,7 +463,7 @@ class FindMany(
         Create Update with modifications query
         and provide search criteria there
 
-        :param args: *Mapping[str,Any] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param on_insert: DocType - document to insert if there is no matched
         document in the collection
         :param session: Optional[ClientSession]
@@ -485,7 +485,7 @@ class FindMany(
 
     def update_many(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         **pymongo_kwargs,
@@ -494,7 +494,7 @@ class FindMany(
         Provide search criteria to the
         [UpdateMany](query.md#updatemany) query
 
-        :param args: *Mapping[str,Any] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param session: Optional[ClientSession]
         :return: [UpdateMany](query.md#updatemany) query
         """
@@ -832,7 +832,7 @@ class FindOne(FindQuery[FindQueryResultType]):
 
     def update(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         response_type: Optional[UpdateResponse] = None,
@@ -842,7 +842,7 @@ class FindOne(FindQuery[FindQueryResultType]):
         Create Update with modifications query
         and provide search criteria there
 
-        :param args: *Mapping[str,Any] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param session: Optional[ClientSession]
         :param bulk_writer: Optional[BulkWriter]
         :param response_type: Optional[UpdateResponse]
@@ -865,7 +865,7 @@ class FindOne(FindQuery[FindQueryResultType]):
 
     def upsert(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         on_insert: "DocType",
         session: Optional[ClientSession] = None,
         response_type: Optional[UpdateResponse] = None,
@@ -875,7 +875,7 @@ class FindOne(FindQuery[FindQueryResultType]):
         Create Update with modifications query
         and provide search criteria there
 
-        :param args: *Mapping[str,Any] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param on_insert: DocType - document to insert if there is no matched
         document in the collection
         :param session: Optional[ClientSession]
@@ -899,7 +899,7 @@ class FindOne(FindQuery[FindQueryResultType]):
 
     def update_one(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         response_type: Optional[UpdateResponse] = None,
@@ -908,7 +908,7 @@ class FindOne(FindQuery[FindQueryResultType]):
         """
         Create [UpdateOne](query.md#updateone) query using modifications and
         provide search criteria there
-        :param args: *Mapping[str,Any] - the modifications to apply
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply
         :param session: Optional[ClientSession] - PyMongo sessions
         :param response_type: Optional[UpdateResponse]
         :return: [UpdateOne](query.md#updateone) query

--- a/beanie/odm/queries/update.py
+++ b/beanie/odm/queries/update.py
@@ -107,7 +107,7 @@ class UpdateMany(UpdateQuery):
 
     def update(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         **pymongo_kwargs,
@@ -115,14 +115,14 @@ class UpdateMany(UpdateQuery):
         """
         Provide modifications to the update query.
 
-        :param args: *Union[dict, Mapping] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param session: Optional[ClientSession]
         :param bulk_writer: Optional[BulkWriter]
         :param pymongo_kwargs: pymongo native parameters for update operation
         :return: UpdateMany query
         """
         self.set_session(session=session)
-        self.update_expressions += args
+        self.update_expressions += args  # type: ignore
         if bulk_writer:
             self.bulk_writer = bulk_writer
         self.pymongo_kwargs.update(pymongo_kwargs)
@@ -130,7 +130,7 @@ class UpdateMany(UpdateQuery):
 
     def upsert(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         on_insert: "DocType",
         session: Optional[ClientSession] = None,
         **pymongo_kwargs,
@@ -138,7 +138,7 @@ class UpdateMany(UpdateQuery):
         """
         Provide modifications to the upsert query.
 
-        :param args: *Union[dict, Mapping] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param on_insert: DocType - document to insert if there is no matched
         document in the collection
         :param session: Optional[ClientSession]
@@ -151,7 +151,7 @@ class UpdateMany(UpdateQuery):
 
     def update_many(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         **pymongo_kwargs,
@@ -159,7 +159,7 @@ class UpdateMany(UpdateQuery):
         """
         Provide modifications to the update query
 
-        :param args: *Union[dict, Mapping] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param session: Optional[ClientSession]
         :param bulk_writer: "BulkWriter" - Beanie bulk writer
         :param pymongo_kwargs: pymongo native parameters for update operation
@@ -227,7 +227,7 @@ class UpdateOne(UpdateQuery):
 
     def update(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         response_type: Optional[UpdateResponse] = None,
@@ -236,7 +236,7 @@ class UpdateOne(UpdateQuery):
         """
         Provide modifications to the update query.
 
-        :param args: *Union[dict, Mapping] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param session: Optional[ClientSession]
         :param bulk_writer: Optional[BulkWriter]
         :param response_type: UpdateResponse
@@ -244,7 +244,7 @@ class UpdateOne(UpdateQuery):
         :return: UpdateMany query
         """
         self.set_session(session=session)
-        self.update_expressions += args
+        self.update_expressions += args  # type: ignore
         if response_type is not None:
             self.response_type = response_type
         if bulk_writer:
@@ -254,7 +254,7 @@ class UpdateOne(UpdateQuery):
 
     def upsert(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         on_insert: "DocType",
         session: Optional[ClientSession] = None,
         response_type: Optional[UpdateResponse] = None,
@@ -263,7 +263,7 @@ class UpdateOne(UpdateQuery):
         """
         Provide modifications to the upsert query.
 
-        :param args: *Union[dict, Mapping] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param on_insert: DocType - document to insert if there is no matched
         document in the collection
         :param session: Optional[ClientSession]
@@ -282,7 +282,7 @@ class UpdateOne(UpdateQuery):
 
     def update_one(
         self,
-        *args: Mapping[str, Any],
+        *args: Union[Mapping[str, Any], List[Mapping[str, Any]]],
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         response_type: Optional[UpdateResponse] = None,
@@ -291,7 +291,7 @@ class UpdateOne(UpdateQuery):
         """
         Provide modifications to the update query. The same as `update()`
 
-        :param args: *Union[dict, Mapping] - the modifications to apply.
+        :param args: *Union[Mapping[str, Any], List[Mapping[str, Any]]] - the modifications to apply.
         :param session: Optional[ClientSession]
         :param bulk_writer: "BulkWriter" - Beanie bulk writer
         :param response_type: Optional[UpdateResponse]


### PR DESCRIPTION
add pipeline support for query update methods like update_many and update_one.

For example:

```python
origin_children_ancestors = ["old-parent-1", "old-parent-2"]
new_children_ancestors = ["new-parent-1", "new-parent-2", "new-parent-3"]

await Categories.find({
    f"ancestors.{i}": val for i, val in enumerate(origin_children_ancestors)
}).update_many(
    [{
        "$set": {"ancestors": {
            "$concatArrays": [
                new_children_ancestors,
                {"$slice": ["$ancestors", len(origin_children_ancestors), {"$size": "$ancestors"}]}
            ]
        }}
    }]
)
```

[#839](https://github.com/roman-right/beanie/issues/839)