### PR TITLE
handle TypeError in validator of PydanticObjectId

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -139,7 +139,7 @@ class PydanticObjectId(ObjectId):
                 v = v.decode("utf-8")
             try:
                 return PydanticObjectId(v)
-            except InvalidId:
+            except (InvalidId, TypeError):
                 raise ValueError("Id must be of type PydanticObjectId")
 
         @classmethod


### PR DESCRIPTION
the initializer of bson.ObjectId might raise `TypeError(f"id must be an instance of (bytes, str, ObjectId), not {type(oid)}")`.

Pydantic validators should raise `ValueError`s or `AssertionError`s instead.