### PR TITLE
Annotate decorators that wrap `Document` methods (#679)

### DIFF
--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -11,11 +11,17 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    TypeVar,
     Union,
 )
 
+from typing_extensions import ParamSpec
+
 if TYPE_CHECKING:
-    from beanie.odm.documents import Document
+    from beanie.odm.documents import AsyncDocMethod, DocType, Document
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class EventTypes(str, Enum):
@@ -136,10 +142,14 @@ class ActionRegistry:
         await asyncio.gather(*coros)
 
 
+# `Any` because there is arbitrary attribute assignment on this type
+F = TypeVar("F", bound=Any)
+
+
 def register_action(
-    event_types: Tuple[Union[List[EventTypes], EventTypes]],
+    event_types: Tuple[Union[List[EventTypes], EventTypes], ...],
     action_direction: ActionDirections,
-):
+) -> Callable[[F], F]:
     """
     Decorator. Base registration method.
     Used inside `before_event` and `after_event`
@@ -154,7 +164,7 @@ def register_action(
         else:
             final_event_types.append(event_type)
 
-    def decorator(f):
+    def decorator(f: F) -> F:
         f.has_action = True
         f.event_types = final_event_types
         f.action_direction = action_direction
@@ -163,7 +173,9 @@ def register_action(
     return decorator
 
 
-def before_event(*args: Union[List[EventTypes], EventTypes]):
+def before_event(
+    *args: Union[List[EventTypes], EventTypes]
+) -> Callable[[F], F]:
     """
     Decorator. It adds action, which should run before mentioned one
     or many events happen
@@ -172,11 +184,13 @@ def before_event(*args: Union[List[EventTypes], EventTypes]):
     :return: None
     """
     return register_action(
-        action_direction=ActionDirections.BEFORE, event_types=args  # type: ignore
+        action_direction=ActionDirections.BEFORE, event_types=args
     )
 
 
-def after_event(*args: Union[List[EventTypes], EventTypes]):
+def after_event(
+    *args: Union[List[EventTypes], EventTypes]
+) -> Callable[[F], F]:
     """
     Decorator. It adds action, which should run after mentioned one
     or many events happen
@@ -186,11 +200,15 @@ def after_event(*args: Union[List[EventTypes], EventTypes]):
     """
 
     return register_action(
-        action_direction=ActionDirections.AFTER, event_types=args  # type: ignore
+        action_direction=ActionDirections.AFTER, event_types=args
     )
 
 
-def wrap_with_actions(event_type: EventTypes):
+def wrap_with_actions(
+    event_type: EventTypes,
+) -> Callable[
+    ["AsyncDocMethod[DocType, P, R]"], "AsyncDocMethod[DocType, P, R]"
+]:
     """
     Helper function to wrap Document methods with
     before and after event listeners
@@ -198,14 +216,16 @@ def wrap_with_actions(event_type: EventTypes):
     :return: None
     """
 
-    def decorator(f: Callable):
+    def decorator(
+        f: "AsyncDocMethod[DocType, P, R]",
+    ) -> "AsyncDocMethod[DocType, P, R]":
         @wraps(f)
         async def wrapper(
-            self,
-            *args,
+            self: "Document",
+            *args: P.args,
             skip_actions: Optional[List[Union[ActionDirections, str]]] = None,
-            **kwargs,
-        ):
+            **kwargs: P.kwargs,
+        ) -> R:
             if skip_actions is None:
                 skip_actions = []
 
@@ -216,7 +236,12 @@ def wrap_with_actions(event_type: EventTypes):
                 exclude=skip_actions,
             )
 
-            result = await f(self, *args, skip_actions=skip_actions, **kwargs)
+            result = await f(
+                self,
+                *args,
+                skip_actions=skip_actions,  # type: ignore[arg-type]
+                **kwargs,
+            )
 
             await ActionRegistry.run_actions(
                 self,

--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -221,7 +221,7 @@ def wrap_with_actions(
     ) -> "AsyncDocMethod[DocType, P, R]":
         @wraps(f)
         async def wrapper(
-            self: "Document",
+            self: "DocType",
             *args: P.args,
             skip_actions: Optional[List[Union[ActionDirections, str]]] = None,
             **kwargs: P.kwargs,

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -6,6 +6,7 @@ from typing import (
     Awaitable,
     Callable,
     ClassVar,
+    Coroutine,
     Dict,
     Iterable,
     List,
@@ -109,8 +110,12 @@ if IS_PYDANTIC_V2:
 DocType = TypeVar("DocType", bound="Document")
 P = ParamSpec("P")
 R = TypeVar("R")
-SyncDocMethod: TypeAlias = Callable[Concatenate[DocType, P], R]
-AsyncDocMethod: TypeAlias = Callable[Concatenate[DocType, P], Awaitable[R]]
+# can describe both sync and async, where R itself is a coroutine
+AnyDocMethod: TypeAlias = Callable[Concatenate[DocType, P], R]
+# describes only async
+AsyncDocMethod: TypeAlias = Callable[
+    Concatenate[DocType, P], Coroutine[Any, Any, R]
+]
 DocumentProjectionType = TypeVar("DocumentProjectionType", bound=BaseModel)
 
 
@@ -983,7 +988,7 @@ class Document(
         """
         return self._previous_saved_state
 
-    @property  # type: ignore
+    @property
     @saved_state_needed
     def is_changed(self) -> bool:
         if self._saved_state == get_dict(
@@ -995,7 +1000,7 @@ class Document(
             return False
         return True
 
-    @property  # type: ignore
+    @property
     @saved_state_needed
     @previous_saved_state_needed
     def has_changed(self) -> bool:

--- a/beanie/odm/utils/self_validation.py
+++ b/beanie/odm/utils/self_validation.py
@@ -1,13 +1,20 @@
 from functools import wraps
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, TypeVar
+
+from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
-    from beanie.odm.documents import DocType
+    from beanie.odm.documents import AsyncDocMethod, DocType
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
-def validate_self_before(f: Callable):
+def validate_self_before(
+    f: "AsyncDocMethod[DocType, P, R]",
+) -> "AsyncDocMethod[DocType, P, R]":
     @wraps(f)
-    async def wrapper(self: "DocType", *args, **kwargs):
+    async def wrapper(self: "DocType", *args: P.args, **kwargs: P.kwargs) -> R:
         await self.validate_self(*args, **kwargs)
         return await f(self, *args, **kwargs)
 

--- a/beanie/odm/utils/state.py
+++ b/beanie/odm/utils/state.py
@@ -1,13 +1,13 @@
 import inspect
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, TypeVar, overload
+from typing import TYPE_CHECKING, TypeVar
 
 from typing_extensions import ParamSpec
 
 from beanie.exceptions import StateManagementIsTurnedOff, StateNotSaved
 
 if TYPE_CHECKING:
-    from beanie.odm.documents import AsyncDocMethod, DocType, SyncDocMethod
+    from beanie.odm.documents import AnyDocMethod, AsyncDocMethod, DocType
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -22,21 +22,9 @@ def check_if_state_saved(self: "DocType"):
         raise StateNotSaved("No state was saved")
 
 
-@overload
 def saved_state_needed(
-    f: "AsyncDocMethod[DocType, P, R]",
-) -> "AsyncDocMethod[DocType, P, R]":
-    ...
-
-
-@overload
-def saved_state_needed(
-    f: "SyncDocMethod[DocType, P, R]",
-) -> "SyncDocMethod[DocType, P, R]":
-    ...
-
-
-def saved_state_needed(f: Callable) -> Callable:
+    f: "AnyDocMethod[DocType, P, R]",
+) -> "AnyDocMethod[DocType, P, R]":
     @wraps(f)
     def sync_wrapper(self: "DocType", *args, **kwargs):
         check_if_state_saved(self)
@@ -45,10 +33,14 @@ def saved_state_needed(f: Callable) -> Callable:
     @wraps(f)
     async def async_wrapper(self: "DocType", *args, **kwargs):
         check_if_state_saved(self)
-        return await f(self, *args, **kwargs)
+        # type ignore because there is no nice/proper way to annotate both sync
+        # and async case without parametrized TypeVar, which is not supported
+        return await f(self, *args, **kwargs)  # type: ignore[misc]
 
     if inspect.iscoroutinefunction(f):
-        return async_wrapper
+        # type ignore because there is no nice/proper way to annotate both sync
+        # and async case without parametrized TypeVar, which is not supported
+        return async_wrapper  # type: ignore[return-value]
     return sync_wrapper
 
 
@@ -63,21 +55,9 @@ def check_if_previous_state_saved(self: "DocType"):
         )
 
 
-@overload
 def previous_saved_state_needed(
-    f: "AsyncDocMethod[DocType, P, R]",
-) -> "AsyncDocMethod[DocType, P, R]":
-    ...
-
-
-@overload
-def previous_saved_state_needed(
-    f: "SyncDocMethod[DocType, P, R]",
-) -> "SyncDocMethod[DocType, P, R]":
-    ...
-
-
-def previous_saved_state_needed(f: Callable) -> Callable:
+    f: "AnyDocMethod[DocType, P, R]",
+) -> "AnyDocMethod[DocType, P, R]":
     @wraps(f)
     def sync_wrapper(self: "DocType", *args, **kwargs):
         check_if_previous_state_saved(self)
@@ -86,10 +66,14 @@ def previous_saved_state_needed(f: Callable) -> Callable:
     @wraps(f)
     async def async_wrapper(self: "DocType", *args, **kwargs):
         check_if_previous_state_saved(self)
-        return await f(self, *args, **kwargs)
+        # type ignore because there is no nice/proper way to annotate both sync
+        # and async case without parametrized TypeVar, which is not supported
+        return await f(self, *args, **kwargs)  # type: ignore[misc]
 
     if inspect.iscoroutinefunction(f):
-        return async_wrapper
+        # type ignore because there is no nice/proper way to annotate both sync
+        # and async case without parametrized TypeVar, which is not supported
+        return async_wrapper  # type: ignore[return-value]
     return sync_wrapper
 
 

--- a/beanie/odm/utils/state.py
+++ b/beanie/odm/utils/state.py
@@ -1,11 +1,16 @@
 import inspect
 from functools import wraps
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, TypeVar, overload
+
+from typing_extensions import ParamSpec
 
 from beanie.exceptions import StateManagementIsTurnedOff, StateNotSaved
 
 if TYPE_CHECKING:
-    from beanie.odm.documents import DocType
+    from beanie.odm.documents import AsyncDocMethod, DocType, SyncDocMethod
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def check_if_state_saved(self: "DocType"):
@@ -17,7 +22,21 @@ def check_if_state_saved(self: "DocType"):
         raise StateNotSaved("No state was saved")
 
 
-def saved_state_needed(f: Callable):
+@overload
+def saved_state_needed(
+    f: "AsyncDocMethod[DocType, P, R]",
+) -> "AsyncDocMethod[DocType, P, R]":
+    ...
+
+
+@overload
+def saved_state_needed(
+    f: "SyncDocMethod[DocType, P, R]",
+) -> "SyncDocMethod[DocType, P, R]":
+    ...
+
+
+def saved_state_needed(f: Callable) -> Callable:
     @wraps(f)
     def sync_wrapper(self: "DocType", *args, **kwargs):
         check_if_state_saved(self)
@@ -44,7 +63,21 @@ def check_if_previous_state_saved(self: "DocType"):
         )
 
 
-def previous_saved_state_needed(f: Callable):
+@overload
+def previous_saved_state_needed(
+    f: "AsyncDocMethod[DocType, P, R]",
+) -> "AsyncDocMethod[DocType, P, R]":
+    ...
+
+
+@overload
+def previous_saved_state_needed(
+    f: "SyncDocMethod[DocType, P, R]",
+) -> "SyncDocMethod[DocType, P, R]":
+    ...
+
+
+def previous_saved_state_needed(f: Callable) -> Callable:
     @wraps(f)
     def sync_wrapper(self: "DocType", *args, **kwargs):
         check_if_previous_state_saved(self)
@@ -60,9 +93,11 @@ def previous_saved_state_needed(f: Callable):
     return sync_wrapper
 
 
-def save_state_after(f: Callable):
+def save_state_after(
+    f: "AsyncDocMethod[DocType, P, R]",
+) -> "AsyncDocMethod[DocType, P, R]":
     @wraps(f)
-    async def wrapper(self: "DocType", *args, **kwargs):
+    async def wrapper(self: "DocType", *args: P.args, **kwargs: P.kwargs) -> R:
         result = await f(self, *args, **kwargs)
         self._save_state()
         return result

--- a/tests/typing/decorators.py
+++ b/tests/typing/decorators.py
@@ -1,0 +1,82 @@
+from typing import Any, Callable, Coroutine
+
+from typing_extensions import Protocol, TypeAlias, assert_type
+
+from beanie import Document
+from beanie.odm.actions import EventTypes, wrap_with_actions
+from beanie.odm.utils.self_validation import validate_self_before
+from beanie.odm.utils.state import (
+    previous_saved_state_needed,
+    save_state_after,
+    saved_state_needed,
+)
+
+
+def sync_func(doc_self: Document, arg1: str, arg2: int, /) -> Document:
+    """
+    Models `Document` sync method that expects self
+    """
+    raise NotImplementedError
+
+
+SyncFunc: TypeAlias = Callable[[Document, str, int], Document]
+
+
+async def async_func(doc_self: Document, arg1: str, arg2: int, /) -> Document:
+    """
+    Models `Document` async method that expects self
+    """
+    raise NotImplementedError
+
+
+AsyncFunc: TypeAlias = Callable[
+    [Document, str, int], Coroutine[Any, Any, Document]
+]
+
+
+def test_wrap_with_actions_preserves_signature() -> None:
+    assert_type(async_func, AsyncFunc)
+    assert_type(wrap_with_actions(EventTypes.SAVE)(async_func), AsyncFunc)
+
+
+def test_save_state_after_preserves_signature() -> None:
+    assert_type(async_func, AsyncFunc)
+    assert_type(save_state_after(async_func), AsyncFunc)
+
+
+def test_validate_self_before_preserves_signature() -> None:
+    assert_type(async_func, AsyncFunc)
+    assert_type(validate_self_before(async_func), AsyncFunc)
+
+
+def test_saved_state_needed_preserves_signature() -> None:
+    assert_type(async_func, AsyncFunc)
+    assert_type(saved_state_needed(async_func), AsyncFunc)
+
+    assert_type(sync_func, SyncFunc)
+    assert_type(saved_state_needed(sync_func), SyncFunc)
+
+
+def test_previous_saved_state_needed_preserves_signature() -> None:
+    assert_type(async_func, AsyncFunc)
+    assert_type(previous_saved_state_needed(async_func), AsyncFunc)
+
+    assert_type(sync_func, SyncFunc)
+    assert_type(previous_saved_state_needed(sync_func), SyncFunc)
+
+
+class ExpectsDocumentSelf(Protocol):
+    def __call__(self, doc_self: Document, /) -> Any:
+        ...
+
+
+def test_document_insert_expects_self() -> None:
+    test_insert: ExpectsDocumentSelf = Document.insert  # noqa: F841
+
+
+def test_document_save_expects_self() -> None:
+    test_insert: ExpectsDocumentSelf = Document.save  # noqa: F841
+
+
+def test_document_replace_expects_self() -> None:
+    test_insert: ExpectsDocumentSelf = Document.replace  # noqa: F841


### PR DESCRIPTION
Type checkers were complaining about missing `self` argument in decorated `Document` methods. This was caused by incomplete annotations of used decorators.