### PR TITLE
fix: allow json_schema_extra as Callable (#884)

### DIFF
--- a/beanie/odm/utils/pydantic.py
+++ b/beanie/odm/utils/pydantic.py
@@ -41,7 +41,7 @@ def parse_model(model_type: Type[BaseModel], data: Any):
 
 def get_extra_field_info(field, parameter: str):
     if IS_PYDANTIC_V2:
-        if field.json_schema_extra is not None:
+        if isinstance(field.json_schema_extra, dict):
             return field.json_schema_extra.get(parameter)
         return None
     else:


### PR DESCRIPTION
Simply check if `field.json_schema_extra` is a `dict`. That way `None` is returned when it is a `Callable`. It seems too complicated to support `Callable`, it would require calling the function with the schema as an argument. I would assume that function call is only done internally in Pydantic so there is not a clear way to do this and retrieve the modified schema after calling the function. So I propose not to support that for now. This means for instance that adding `original_field` to the JSON schema of a `beanie.BackLink` field in a callable would not be supported...

See #884 